### PR TITLE
Add support for GSL 2.0.

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -418,6 +418,9 @@
 /* Building TeXInfo documentation requires version greater than 4.8 */
 #undef MAKEINFO_VERSION
 
+/* GSL major version number */
+#undef NCO_GSL_MAJOR_VERSION
+
 /* GSL minor version number */
 #undef NCO_GSL_MINOR_VERSION
 

--- a/configure.ac
+++ b/configure.ac
@@ -649,15 +649,18 @@ if test "${enable_gsl}" != 'no'; then
 	LIBS="${nco_LIBS_no_GSL}"  
 	CPPFLAGS="${nco_CPPFLAGS_no_GSL}"
     elif test "${enable_gsl}" = 'yes'; then
-# Assumes GSL version in form 1.[0-9]+  extract minor version only   
+# Assumes GSL version in form [0-9].[0-9]+  extract major & minor version
 	GSL_VER="`${GSL_CONFIG} --version`" 
-	GSL_VER=`echo "${GSL_VER}" | sed -e 's/^1\.//'`  
+	GSL_VER_MAJOR="`echo "${GSL_VER}" | cut -d '.' -f 1`"
+	GSL_VER_MINOR="`echo "${GSL_VER}" | cut -d '.' -f 2`"
 	if test "x${GSL_VER}" = 'x'; then
 	    # 20100115: Fix for machines like bluefire that lack gsl-config
-	    GSL_VER='4' 
+	    GSL_VER_MAJOR='1' 
+	    GSL_VER_MINOR='4' 
 	fi
 	AC_DEFINE(ENABLE_GSL,1,Compile operators with GSL support)
-	AC_DEFINE_UNQUOTED(NCO_GSL_MINOR_VERSION,${GSL_VER},GSL minor version number)
+	AC_DEFINE_UNQUOTED(NCO_GSL_MAJOR_VERSION,${GSL_VER_MAJOR},GSL major version number)
+	AC_DEFINE_UNQUOTED(NCO_GSL_MINOR_VERSION,${GSL_VER_MINOR},GSL minor version number)
 	AC_MSG_NOTICE([GSL support enabled])
     fi
 fi

--- a/src/nco++/fmc_gsl_cls.cc
+++ b/src/nco++/fmc_gsl_cls.cc
@@ -117,7 +117,7 @@ void gsl_cls::gsl_ini_sf(void) {
     gpr_vtr.push_back(gpr_cls("gsl_sf_debye_3",f_unn(gsl_sf_debye_3_e),hnd_fnc_x,NC_DOUBLE));
     gpr_vtr.push_back(gpr_cls("gsl_sf_debye_4",f_unn(gsl_sf_debye_4_e),hnd_fnc_x,NC_DOUBLE));
 
-# if NCO_GSL_MINOR_VERSION >= 8
+# if NCO_GSL_MINOR_VERSION >= 8 || NCO_GSL_MAJOR_VERSION >= 2
       gpr_vtr.push_back(gpr_cls("gsl_sf_debye_5",f_unn(gsl_sf_debye_5_e),hnd_fnc_x,NC_DOUBLE));
       gpr_vtr.push_back(gpr_cls("gsl_sf_debye_6",f_unn(gsl_sf_debye_6_e),hnd_fnc_x,NC_DOUBLE));
 # endif // NCO_GSL_MINOR_VERSION < 8
@@ -131,7 +131,7 @@ void gsl_cls::gsl_ini_sf(void) {
     gpr_vtr.push_back(gpr_cls("gsl_sf_ellint_Kcomp",f_unn(gsl_sf_ellint_Kcomp_e),hnd_fnc_nd,P1DBLMD));
     gpr_vtr.push_back(gpr_cls("gsl_sf_ellint_Ecomp",f_unn(gsl_sf_ellint_Ecomp_e),hnd_fnc_nd,P1DBLMD));
 
-# if NCO_GSL_MINOR_VERSION >= 9 
+# if NCO_GSL_MINOR_VERSION >= 9 || NCO_GSL_MAJOR_VERSION >= 2
       gpr_vtr.push_back(gpr_cls("gsl_sf_ellint_Pcomp",f_unn(gsl_sf_ellint_Pcomp_e),hnd_fnc_nd,P2DBLMD));
       gpr_vtr.push_back(gpr_cls("gsl_sf_ellint_Dcomp",f_unn(gsl_sf_ellint_Dcomp_e),hnd_fnc_nd,P1DBLMD));
 # endif // NCO_GSL_MINOR_VERSION < 9
@@ -178,7 +178,7 @@ void gsl_cls::gsl_ini_sf(void) {
     gpr_vtr.push_back(gpr_cls("gsl_sf_expint_E1_scaled",f_unn(gsl_sf_expint_E1_scaled_e),hnd_fnc_x,NC_DOUBLE));
     gpr_vtr.push_back(gpr_cls("gsl_sf_expint_E2_scaled",f_unn(gsl_sf_expint_E2_scaled_e),hnd_fnc_x,NC_DOUBLE));
 
-# if NCO_GSL_MINOR_VERSION >= 10 
+# if NCO_GSL_MINOR_VERSION >= 10 || NCO_GSL_MAJOR_VERSION >= 2
       gpr_vtr.push_back(gpr_cls("gsl_sf_expint_En",f_unn(gsl_sf_expint_En_e),hnd_fnc_xd,NC_INT));
       gpr_vtr.push_back(gpr_cls("gsl_sf_expint_En_scaled",f_unn(gsl_sf_expint_En_scaled_e),hnd_fnc_xd,NC_INT));
 # endif // NCO_GSL_MINOR_VERSION < 10
@@ -271,10 +271,14 @@ void gsl_cls::gsl_ini_sf(void) {
     gpr_vtr.push_back(gpr_cls("gsl_sf_legendre_Q1",f_unn(gsl_sf_legendre_Q1_e),hnd_fnc_x,NC_DOUBLE));
     gpr_vtr.push_back(gpr_cls("gsl_sf_legendre_Ql",f_unn(gsl_sf_legendre_Ql_e),hnd_fnc_xd,NC_INT));
     gpr_vtr.push_back(gpr_cls("gsl_sf_legendre_Plm",f_unn(gsl_sf_legendre_Plm_e),hnd_fnc_iid));
+# if NCO_GSL_MAJOR_VERSION < 2
     gpr_vtr.push_back(gpr_cls("gsl_sf_legendre_Plm_array",f_unn(gsl_sf_legendre_Plm_array),hnd_fnc_iidpd,PLEGEND));
+# endif // NCO_GSL_MAJOR_VERSION < 2
     // gpr_vtr.push_back(gpr_cls("gsl_sf_legendre_Plm_deriv_array",f_unn(gsl_sf_legendre_Plm_deriv_array),));
     gpr_vtr.push_back(gpr_cls("gsl_sf_legendre_sphPlm",f_unn(gsl_sf_legendre_sphPlm_e),hnd_fnc_iid));
+# if NCO_GSL_MAJOR_VERSION < 2
     gpr_vtr.push_back(gpr_cls("gsl_sf_legendre_sphPlm_array",f_unn(gsl_sf_legendre_sphPlm_array),hnd_fnc_iidpd,PLEGEND));
+# endif // NCO_GSL_MAJOR_VERSION < 2
     // gpr_vtr.push_back(gpr_cls("gsl_sf_legendre_sphPlm_deriv_array",f_unn(gsl_sf_legendre_sphPlm_deriv_array),));
     // gpr_vtr.push_back(gpr_cls("gsl_sf_legendre_array_size",f_unn(gsl_sf_legendre_array_size),));
     gpr_vtr.push_back(gpr_cls("gsl_sf_conicalP_half",f_unn(gsl_sf_conicalP_half_e),hnd_fnc_nd,P2DBL));
@@ -309,7 +313,7 @@ void gsl_cls::gsl_ini_sf(void) {
     // gpr_vtr.push_back(gpr_cls("gsl_sf_complex_psi",f_unn(gsl_sf_complex_psi_e),hnd_fnc_x,NC_DOUBLE));
     gpr_vtr.push_back(gpr_cls("gsl_sf_psi_1_int",f_unn(gsl_sf_psi_1_int_e),hnd_fnc_x,NC_INT));
    
-# if NCO_GSL_MINOR_VERSION >= 5 
+# if NCO_GSL_MINOR_VERSION >= 5 || NCO_GSL_MAJOR_VERSION >= 2
       gpr_vtr.push_back(gpr_cls("gsl_sf_psi_1",f_unn(gsl_sf_psi_1_e),hnd_fnc_x,NC_DOUBLE));
 # endif // NCO_GSL_MINOR_VERSION < 5
 
@@ -332,7 +336,7 @@ void gsl_cls::gsl_ini_sf(void) {
     gpr_vtr.push_back(gpr_cls("gsl_sf_zeta_int",f_unn(gsl_sf_zeta_int_e),hnd_fnc_x,NC_INT));
     gpr_vtr.push_back(gpr_cls("gsl_sf_zeta",f_unn(gsl_sf_zeta_e),hnd_fnc_x,NC_DOUBLE));
 
-# if NCO_GSL_MINOR_VERSION >= 5 
+# if NCO_GSL_MINOR_VERSION >= 5 || NCO_GSL_MAJOR_VERSION >= 2
       gpr_vtr.push_back(gpr_cls("gsl_sf_zetam1",f_unn(gsl_sf_zetam1_e),hnd_fnc_x,NC_DOUBLE));
       gpr_vtr.push_back(gpr_cls("gsl_sf_zetam1_int",f_unn(gsl_sf_zetam1_int_e),hnd_fnc_x,NC_INT));
 # endif // NCO_GSL_MINOR_VERSION < 5
@@ -386,7 +390,7 @@ void gsl_cls::gsl_ini_cdf(void){
     gpr_vtr.push_back(gpr_cls("gsl_cdf_exponential_Q",f_unn(gsl_cdf_exponential_Q),hnd_fnc_nd,P2DBLX));
     gpr_vtr.push_back(gpr_cls("gsl_cdf_exponential_Pinv",f_unn(gsl_cdf_exponential_Pinv),hnd_fnc_nd,P2DBLX));
     gpr_vtr.push_back(gpr_cls("gsl_cdf_exponential_Qinv",f_unn(gsl_cdf_exponential_Qinv),hnd_fnc_nd,P2DBLX));
-# if NCO_GSL_MINOR_VERSION >= 6
+# if NCO_GSL_MINOR_VERSION >= 6 || NCO_GSL_MAJOR_VERSION >= 2
     gpr_vtr.push_back(gpr_cls("gsl_cdf_exppow_P",f_unn(gsl_cdf_exppow_P),hnd_fnc_nd,P3DBLX));
     gpr_vtr.push_back(gpr_cls("gsl_cdf_exppow_Q",f_unn(gsl_cdf_exppow_Q),hnd_fnc_nd,P3DBLX));
 # endif
@@ -397,14 +401,14 @@ void gsl_cls::gsl_ini_cdf(void){
 
     gpr_vtr.push_back(gpr_cls("gsl_cdf_fdist_P",f_unn(gsl_cdf_fdist_P),hnd_fnc_nd,P3DBLX));
     gpr_vtr.push_back(gpr_cls("gsl_cdf_fdist_Q",f_unn(gsl_cdf_fdist_Q),hnd_fnc_nd,P3DBLX));
-# if NCO_GSL_MINOR_VERSION >= 8 
+# if NCO_GSL_MINOR_VERSION >= 8 || NCO_GSL_MAJOR_VERSION >= 2
     gpr_vtr.push_back(gpr_cls("gsl_cdf_fdist_Pinv",f_unn(gsl_cdf_fdist_Pinv),hnd_fnc_nd,P3DBLX));
     gpr_vtr.push_back(gpr_cls("gsl_cdf_fdist_Qinv",f_unn(gsl_cdf_fdist_Qinv),hnd_fnc_nd,P3DBLX));
 # endif // NCO_GSL_MINOR_VERSION < 8
 
     gpr_vtr.push_back(gpr_cls("gsl_cdf_beta_P",f_unn(gsl_cdf_beta_P),hnd_fnc_nd,P3DBLX));
     gpr_vtr.push_back(gpr_cls("gsl_cdf_beta_Q",f_unn(gsl_cdf_beta_Q),hnd_fnc_nd,P3DBLX));
-# if NCO_GSL_MINOR_VERSION >= 8 
+# if NCO_GSL_MINOR_VERSION >= 8 || NCO_GSL_MAJOR_VERSION >= 2
     gpr_vtr.push_back(gpr_cls("gsl_cdf_beta_Pinv",f_unn(gsl_cdf_beta_Pinv),hnd_fnc_nd,P3DBLX));
     gpr_vtr.push_back(gpr_cls("gsl_cdf_beta_Qinv",f_unn(gsl_cdf_beta_Qinv),hnd_fnc_nd,P3DBLX));
 # endif // NCO_GSL_MINOR_VERSION < 8
@@ -474,7 +478,7 @@ void gsl_cls::gsl_ini_ran(void){
   gpr_vtr.push_back(gpr_cls("gsl_ran_beta_pdf",f_unn(gsl_ran_beta_pdf),hnd_fnc_nd,P3DBLX));
 
   gpr_vtr.push_back(gpr_cls("gsl_ran_binomial",f_unn(gsl_ran_binomial),hnd_fnc_udrdu));
-# if NCO_GSL_MINOR_VERSION >= 7 
+# if NCO_GSL_MINOR_VERSION >= 7 || NCO_GSL_MAJOR_VERSION >= 2
   gpr_vtr.push_back(gpr_cls("gsl_ran_binomial_knuth",f_unn(gsl_ran_binomial_knuth),hnd_fnc_udrdu));
 # endif
   gpr_vtr.push_back(gpr_cls("gsl_ran_binomial_tpe",f_unn(gsl_ran_binomial_tpe),hnd_fnc_udrdu));
@@ -508,14 +512,14 @@ void gsl_cls::gsl_ini_ran(void){
   gpr_vtr.push_back(gpr_cls("gsl_ran_gamma",f_unn(gsl_ran_gamma),hnd_fnc_rnd,P2DBLX));
   gpr_vtr.push_back(gpr_cls("gsl_ran_gamma_int",f_unn(gsl_ran_gamma_int),hnd_fnc_ru));
   gpr_vtr.push_back(gpr_cls("gsl_ran_gamma_pdf",f_unn(gsl_ran_gamma_pdf),hnd_fnc_nd,P3DBLX));
-# if NCO_GSL_MINOR_VERSION >= 8 
+# if NCO_GSL_MINOR_VERSION >= 8 || NCO_GSL_MAJOR_VERSION >= 2
   gpr_vtr.push_back(gpr_cls("gsl_ran_gamma_mt",f_unn(gsl_ran_gamma_mt),hnd_fnc_rnd,P2DBLX));
   gpr_vtr.push_back(gpr_cls("gsl_ran_gamma_knuth",f_unn(gsl_ran_gamma_knuth),hnd_fnc_rnd,P2DBLX));
 # endif // NCO_GSL_MINOR_VERSION < 8
 
   gpr_vtr.push_back(gpr_cls("gsl_ran_gaussian",f_unn(gsl_ran_gaussian),hnd_fnc_rnd,P1DBLX));
   gpr_vtr.push_back(gpr_cls("gsl_ran_gaussian_ratio_method",f_unn(gsl_ran_gaussian_ratio_method),hnd_fnc_rnd,P1DBLX));
-# if NCO_GSL_MINOR_VERSION >= 8 
+# if NCO_GSL_MINOR_VERSION >= 8 || NCO_GSL_MAJOR_VERSION >= 2
   gpr_vtr.push_back(gpr_cls("gsl_ran_gaussian_ziggurat",f_unn(gsl_ran_gaussian_ziggurat),hnd_fnc_rnd,P1DBLX));
 # endif // NCO_GSL_MINOR_VERSION < 8
   gpr_vtr.push_back(gpr_cls("gsl_ran_gaussian_pdf",f_unn(gsl_ran_gaussian_pdf),hnd_fnc_nd,P2DBLX));
@@ -747,7 +751,7 @@ void gsl_cls::gsl_ini_stats(void){
   }
 
   gpr_vtr.push_back(gpr_cls("gsl_stats_covariance",f_unn(ncap_void),hnd_fnc_stat4,PS_COV));
-# if NCO_GSL_MINOR_VERSION >= 10
+# if NCO_GSL_MINOR_VERSION >= 10 || NCO_GSL_MAJOR_VERSION >= 2
   gpr_vtr.push_back(gpr_cls("gsl_stats_correlation",f_unn(ncap_void),hnd_fnc_stat4,PS_COR));
 # endif // NCO_GSL_MINOR_VERSION < 10
   gpr_vtr.push_back(gpr_cls("gsl_stats_pvariance",f_unn(ncap_void),hnd_fnc_stat4,PS_PVAR));
@@ -3620,7 +3624,7 @@ var_sct *gsl_cls::hnd_fnc_stat4(bool& is_mtd,std::vector<RefAST>&args_vtr,gpr_cl
      default: nco_dfl_case_nc_type_err(); break;    
      }  break;  
   
-# if NCO_GSL_MINOR_VERSION >= 10
+# if NCO_GSL_MINOR_VERSION >= 10 || NCO_GSL_MAJOR_VERSION >= 2
    case PS_COR:
      switch(var_arr[0]->type){
        case NC_FLOAT:  r_val=gsl_stats_float_correlation( var_arr[0]->val.fp,d1_srd,var_arr[3]->val.fp,d2_srd,sz1 );break;

--- a/src/nco++/fmc_gsl_cls.hh
+++ b/src/nco++/fmc_gsl_cls.hh
@@ -40,6 +40,10 @@
 #include "ncap2_utl.hh"
 #include "vtl_cls.hh"
 
+#ifndef NCO_GSL_MAJOR_VERSION
+# define NCO_GSL_MAJOR_VERSION 1
+#endif // NCO_GSL_MAJOR_VERSION
+
 #ifndef NCO_GSL_MINOR_VERSION
 #ifdef _MSC_VER
 # define NCO_GSL_MINOR_VERSION 7


### PR DESCRIPTION
As reported in #19, NCO fails to build with GSL 2.0.

This PR forwards the changes added to the Debian package to build successfully with GSL 2.0.

Both the major & minor version of GSL are now used to determine which features to enable.