### PR TITLE
nco: awk commands in configure are not compatible with nawk

### DIFF
--- a/configure
+++ b/configure
@@ -3601,7 +3601,7 @@ fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $MKDIR_P" >&5
 $as_echo "$MKDIR_P" >&6; }
 
-for ac_prog in gawk mawk nawk awk
+for ac_prog in gawk mawk awk
 do
   # Extract the first word of "$ac_prog", so it can be a program name with args.
 set dummy $ac_prog; ac_word=$2


### PR DESCRIPTION
nco configure fails if nawk is available but not gawk or mawk. Some awk commands seem to use syntax unavailable in nawk.