### PR TITLE
Typo fixes

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -4768,7 +4768,7 @@
 	Eliminate pre-emptive check in nco_var_dmn_rdr_mtd() for condition
 	which was not illegal yet led to exit() anyway.
 	All that was necessary was to eliminate the exit() call.
-	False-postive errors were produced for variables that were record
+	False-positive errors were produced for variables that were record
 	in input, fixed in output, and themselves lacked the record
 	dimension, i.e., they became fixed (were neutered?) because record
 	dimension had to be fixed to satisfy re-ordering of other variables.

--- a/src/nco++/ncap2_utl.cc
+++ b/src/nco++/ncap2_utl.cc
@@ -1620,7 +1620,7 @@ ncap_var_var_op   /* [fnc] Add two variables */
     if( (var1->has_dpl_dmn ==-1 || var2->has_dpl_dmn==-1) && var1->sz >1 && var2->sz>1){  
       if(var1->sz != var2->sz) {
 	std::ostringstream os;
-	os<<"Hyperslabbed variable:"<<var1->nm <<" and variable:"<<var2->nm <<" have differnet number of elements, so cannot perform arithmetic operation.";
+	os<<"Hyperslabbed variable:"<<var1->nm <<" and variable:"<<var2->nm <<" have different number of elements, so cannot perform arithmetic operation.";
 	err_prn(fnc_nm,os.str());
       }
       if( nco_shp_chk(var1,var2)==False){ 

--- a/src/nco/nco_ppc.c
+++ b/src/nco/nco_ppc.c
@@ -216,7 +216,7 @@ nco_ppc_set_dflt /* Set PPC value for all non-coordinate variables for --ppc def
     ppc_val=(int)strtol(ppc_arg,&sng_cnv_rcd,NCO_SNG_CNV_BASE10);
     if(*sng_cnv_rcd) nco_sng_cnv_err(ppc_arg,"strtol",sng_cnv_rcd);
     if(ppc_val <= 0){
-      (void)fprintf(stdout,"%s ERROR Number of Significant Digits (NSD) must be postive. Default is specified as %d. HINT: Decimal Significant Digit (DSD) rounding does accept negative arguments (number of digits in front of the decimal point). However, the DSD argument must be prefixed by a period or \"dot\", e.g., \"--ppc foo=.-2\", to distinguish it from NSD quantization.\n",nco_prg_nm_get(),ppc_val);
+      (void)fprintf(stdout,"%s ERROR Number of Significant Digits (NSD) must be positive. Default is specified as %d. HINT: Decimal Significant Digit (DSD) rounding does accept negative arguments (number of digits in front of the decimal point). However, the DSD argument must be prefixed by a period or \"dot\", e.g., \"--ppc foo=.-2\", to distinguish it from NSD quantization.\n",nco_prg_nm_get(),ppc_val);
       nco_exit(EXIT_FAILURE);
     } /* endif */    
   } /* end if */
@@ -259,7 +259,7 @@ nco_ppc_set_var
     ppc_val=(int)strtol(ppc_arg,&sng_cnv_rcd,NCO_SNG_CNV_BASE10);
     if(*sng_cnv_rcd) nco_sng_cnv_err(ppc_arg,"strtol",sng_cnv_rcd);
     if(ppc_val <= 0){
-      (void)fprintf(stdout,"%s ERROR Number of Significant Digits (NSD) must be postive. Specified value for %s is %d. HINT: Decimal Significant Digit (DSD) rounding does accept negative arguments (number of digits in front of the decimal point). However, the DSD argument must be prefixed by a period or \"dot\", e.g., \"--ppc foo=.-2\", to distinguish it from NSD quantization.\n",nco_prg_nm_get(),var_nm,ppc_val);
+      (void)fprintf(stdout,"%s ERROR Number of Significant Digits (NSD) must be positive. Specified value for %s is %d. HINT: Decimal Significant Digit (DSD) rounding does accept negative arguments (number of digits in front of the decimal point). However, the DSD argument must be prefixed by a period or \"dot\", e.g., \"--ppc foo=.-2\", to distinguish it from NSD quantization.\n",nco_prg_nm_get(),var_nm,ppc_val);
       nco_exit(EXIT_FAILURE);
     } /* endif */    
   } /* end else */


### PR DESCRIPTION
The lintian QA tool reported a couple of spelling errors for NCO 4.5.4 as part of the Debian package build:

 * differnet -> different
 * postive   -> positive