### PR TITLE
Fix spelling errors.

### DIFF
--- a/src/nco++/fmc_gsl_cls.cc
+++ b/src/nco++/fmc_gsl_cls.cc
@@ -2887,7 +2887,7 @@ var_sct *gsl_cls::hnd_fnc_uerx(bool& is_mtd,std::vector<RefAST>&args_vtr,gpr_cls
           if( ui64p[idx]>INT_MAX ) {
 	    // bomb out if necessary  
             ostringstream os; 
-            os<<"Possible integer overflow. You have rquested the generation of integers up to the value of " <<ui64p[idx]<<" .This is greater than "<<INT_MAX<<" - the maximum value that can be stored in the netcdf datatype NC_INT. Consider using another random number generator e.g., ran0,fishman18 or knuthran. Consult the GSL manual for details. Alternatively recompile nco for netcdf4 and set the compile flag NCO_TYP_GSL_UINT=NC_UINT\n"; 
+            os<<"Possible integer overflow. You have requested the generation of integers up to the value of " <<ui64p[idx]<<" .This is greater than "<<INT_MAX<<" - the maximum value that can be stored in the netcdf datatype NC_INT. Consider using another random number generator e.g., ran0,fishman18 or knuthran. Consult the GSL manual for details. Alternatively recompile nco for netcdf4 and set the compile flag NCO_TYP_GSL_UINT=NC_UINT\n"; 
             err_prn(sfnm,os.str());
           }
           

--- a/src/nco/nco_omp.c
+++ b/src/nco/nco_omp.c
@@ -77,7 +77,7 @@ nco_openmp_ini /* [fnc] Initialize OpenMP threading environment */
 
   if(thr_nbr == 0)
     if(nco_dbg_lvl_get() >= nco_dbg_scl && nco_dbg_lvl_get() != nco_dbg_dev )
-      (void)fprintf(fp_stderr,"%s: INFO User did not specify thread request > 0 on command line. NCO will automatically assign threads based on OMP_NUM_THREADS environment and machine capabilities.\nHINT: Not specifiying any --thr_nbr (or specifying --thr_nbr=0) causes NCO to try to pick the optimal thread number. Specifying --thr_nbr=1 tells NCO to execute in Uni-Processor (UP) (i.e., single-threaded) mode.\n",nco_prg_nm_get());
+      (void)fprintf(fp_stderr,"%s: INFO User did not specify thread request > 0 on command line. NCO will automatically assign threads based on OMP_NUM_THREADS environment and machine capabilities.\nHINT: Not specifying any --thr_nbr (or specifying --thr_nbr=0) causes NCO to try to pick the optimal thread number. Specifying --thr_nbr=1 tells NCO to execute in Uni-Processor (UP) (i.e., single-threaded) mode.\n",nco_prg_nm_get());
 
   if(thr_nbr > 0) USR_SPC_THR_RQS=True;
 


### PR DESCRIPTION
These spelling errors were reported by the lintian QA tool for the Debian package build:

 rquested    -> requested
 specifiying -> specifying