### PR TITLE
Add support to double backslashes as a flag for literal characters

### DIFF
--- a/bm/NCO_rgr.pm
+++ b/bm/NCO_rgr.pm
@@ -2918,6 +2918,17 @@ if($RUN_NETCDF4_TESTS_VERSION_GE_431){
     $tst_cmd[3]="SS_OK";   
     NCO_bm::tst_run(\@tst_cmd);
     $#tst_cmd=0; # Reset array
+
+# ncks #119
+# ncks -O --dlm=':' --gaa 'foo=bar:foo2=bar2:foo3,foo4=Thu Sep 15 13\\:03\\:18 PDT 2016:foo5=bar6’ ~/nco/data/in.nc ~/foo.nc
+# ncks -M ~/foo.nc | grep foo6 | cut -d ' ' -f 11
+    $dsc_sng="Multi-argument parsing test when some of the delimiters are handled by backslashes";
+    $tst_cmd[0]="ncks -O --dlm=':' $nco_D_flg --gaa foo=bar:foo2=bar2:foo3,foo4='Thu Sep 15 13\\:03\\:18 PDT 2016:foo5=bar6' $in_pth_arg in.nc %tmp_fl_00%";
+    $tst_cmd[1]="ncks -M %tmp_fl_00% | grep foo4 | cut -d ' ' -f 11-16";
+    $tst_cmd[2]="Thu Sep 15 13:03:18 PDT 2016";
+    $tst_cmd[3]="SS_OK";   
+    NCO_bm::tst_run(\@tst_cmd);
+    $#tst_cmd=0; # Reset array
 	
 #####################
 #### ncpdq tests #### -OK !

--- a/src/nco/nco_mta.c
+++ b/src/nco/nco_mta.c
@@ -256,5 +256,5 @@ nco_join_sng /* [fnc] Join strings with delimiter */
     if(sng_idx<sng_nbr-1) strcpy(final_string+copy_counter+temp_length,nco_mta_dlm);
     copy_counter+=(temp_length+1);
   }
-  return strcat(final_string,"\0");
+  return final_string;
 }

--- a/src/nco/nco_mta.c
+++ b/src/nco/nco_mta.c
@@ -82,8 +82,8 @@ nco_kvm_prn(kvm_sct kvm)
 
 char *nco_remove_backslash(char *args)
 {/* Purpose: recursively remove the backslash from the string*/
-  char* backslash_pos=strstr(args, "\\");
-  int absolute_pos=backslash_pos-args;
+  char* backslash_pos=strstr(args, "\\"); 
+  int absolute_pos=backslash_pos-args;/*get memory address offset*/
 
   memmove(&args[absolute_pos], &args[absolute_pos+1], strlen(args)-absolute_pos);
 
@@ -119,23 +119,23 @@ nco_sng_split /* [fnc] Split string by delimiter */
   if(sng_fnl){
     char *temp_pt = temp;
     while(temp_pt){
-      if(temp_pt == temp || (temp_pt-1)[0]!='\\')
+      if(temp_pt==temp||(temp_pt-1)[0]!='\\')
         idx_lst[index++]=temp_pt - temp;
       temp_pt=strstr(temp_pt+1, delimiter);
     }
     idx_lst[index]=strlen(temp);
 
     /*Copy the first token. since it is not preceded by a delimiter*/
-    sng_fnl[0] = (char*)malloc(idx_lst[1]+1);
+    sng_fnl[0]=(char*)malloc(idx_lst[1]+1);
     memcpy(sng_fnl[0], temp, idx_lst[1]);
     sng_fnl[0][idx_lst[1]]='\0';
 
     /*Copy the rest of the tokens based on the positions of the delimiter*/
     for(int index=1; index<counter; index++){
-      int sng_size = idx_lst[index + 1] - idx_lst[index] - strlen(delimiter);
-      sng_fnl[index] = (char*)malloc(sng_size + 1);
+      int sng_size=idx_lst[index + 1] - idx_lst[index] - strlen(delimiter);
+      sng_fnl[index]=(char*)malloc(sng_size + 1);
       memcpy(sng_fnl[index], temp + idx_lst[index] + strlen(delimiter), sng_size);
-      sng_fnl[index][sng_size] = '\0';  
+      sng_fnl[index][sng_size]='\0';  
     }
     nco_free(temp);
   }else{
@@ -239,6 +239,9 @@ nco_join_sng /* [fnc] Join strings with delimiter */
 (const char **sng_lst, /* I [sng] List of strings being connected */
  const int sng_nbr) /* I [int] Number of strings */
 {
+  /* Purpose: join the strings with delimiters. It will be used when the number of
+   * arguments is larger than 1; usually it is in the old NCO argument style*/
+
   char *nco_mta_dlm=nco_mta_dlm_get(); /* [sng] Multi-argument delimiter */
 
   if(sng_nbr == 1) return strdup(sng_lst[0]);

--- a/src/nco/nco_mta.c
+++ b/src/nco/nco_mta.c
@@ -83,12 +83,11 @@ nco_kvm_prn(kvm_sct kvm)
 char *nco_remove_backslash(char *args)
 {/* Purpose: recursively remove the backslash from the string*/
   char* backslash_pos=strstr(args, "\\"); 
-  int absolute_pos=backslash_pos-args;/*get memory address offset*/
-
-  memmove(&args[absolute_pos], &args[absolute_pos+1], strlen(args)-absolute_pos);
-
-  if(strstr(args, "\\"))
+  if(backslash_pos){
+    int absolute_pos=backslash_pos-args;/*get memory address offset*/
+    memmove(&args[absolute_pos], &args[absolute_pos+1], strlen(args)-absolute_pos);
     return nco_remove_backslash(args);
+  }
   else
     return args;
 }
@@ -220,9 +219,7 @@ nco_arg_mlt_prs /* [fnc] main parser, split the string and assign to kvm structu
       char *temp_value=strdup(individual_args[sub_idx]);
 	    temp_value=(char *)realloc(temp_value,strlen(temp_value)+strlen(value)+1);
       temp_value=strcat(temp_value,value);
-      if(strstr(temp_value, "\\"))
-        temp_value=nco_remove_backslash(temp_value);
-      kvm_set[kvm_idx++]=nco_sng2kvm(temp_value);
+      kvm_set[kvm_idx++]=nco_sng2kvm(nco_remove_backslash(temp_value));
       nco_free(temp_value);
     }//end inner loop
     nco_sng_lst_free_void(individual_args,nco_count_blocks(set_of_keys,nco_mta_sub_dlm));

--- a/src/nco/nco_mta.h
+++ b/src/nco/nco_mta.h
@@ -49,7 +49,7 @@ extern "C" {
   (kvm_sct kvm); /* [fnc] kvm to print */
 
   char *
-  nco_strip_backslash
+  nco_remove_backslash
   (char* args);
 
   char ** /* O [sng] Group of split strings */


### PR DESCRIPTION
Now `ncks -O --dlm=':' --gaa 'foo=bar:foo2=bar2:foo3,foo4=Thu Sep 15 13\\:03\\:18 PDT 2016' ~/nco/data/in.nc ~/foo.nc` is supported. Users can use double backslashes (please note that single backslash might disappear) when they think the delimiters should have their literal meanings.