### PR TITLE
Fix spelling errors.

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -6637,10 +6637,10 @@
 2011-06-26  Charlie Zender  <zender@uci.edu>
 
 	* Remove UDUNITS section of configure.in because it was overly
-	complex to maintain with UDUNITS2 which supercedes it
+	complex to maintain with UDUNITS2 which supersedes it
 
 	* Remove DAP-OPENDAP section of configure.in because it was overly
-	complex to maintain with DAP-NETCDF which supercedes it
+	complex to maintain with DAP-NETCDF which supersedes it
 
 	* Re-introduce ENABLE_NETCDF4
 

--- a/doc/highlights_old.shtml
+++ b/doc/highlights_old.shtml
@@ -242,7 +242,7 @@ Improve IRIX&nbsp;6.5 support</li>
 <li><b>NCO 3.2.0</b>: More forgiving exclusion list (<tt>-x -v <i>var_nm</i></tt>) <a href="http://nco.sf.net/nco.html#xcl">handling</a>; Fix <tt>rmssdn</tt> normalization; Support Mac OS&nbsp;X on Intel; Documentation bugfixes</li>
 <li><b>NCO 3.1.9</b>: <tt>ncap2</tt> in RPM packages; Quieter output; AIX <tt>configure</tt> supports <tt>ncap2</tt>; Update to DAP for netCDF 3.6.2; Fix <tt>nc[erw]a</tt> for coordinate min/max/ttl; <tt>ncecat</tt> allows files to differ in record dimension size</li>
 <li><b>NCO 3.1.8</b>: Support <tt>_FillValue</tt> with compile-time switch; Debian package synchronized, includes <tt>ncap2</tt></li>
-<li><b>NCO 3.1.7</b>: <tt>ncap2</tt> &ldquo;double-parsing&rdquo;, array initialization, supercedes <tt>ncap</tt></li>
+<li><b>NCO 3.1.7</b>: <tt>ncap2</tt> &ldquo;double-parsing&rdquo;, array initialization, supersedes <tt>ncap</tt></li>
 <li><b>NCO 3.1.6</b>: Support <a href="http://nco.sf.net/nco.html#srd">stride</a> in all hyperslabbing operators; change more WARNINGs to INFOs</li>
 <li><b>NCO 3.1.5</b>: New <tt>ncap2</tt> array and hyperslab features; change some WARNINGs to INFOs, add Pathscale and update PGI and Intel compiler support</li>
 <li><b>NCO 3.1.4</b>: Fix <tt>ncbo</tt> memory problem; report timer results</li>

--- a/man/ncap2.1
+++ b/man/ncap2.1
@@ -35,7 +35,7 @@ ncap2 [\-3] [\-4] [\-6] [\-7] [\-A] [\-\-bfr
 .SH DESCRIPTION
 .PP
 .B ncap2
-supercedes and is backwards-compatible with 
+supersedes and is backwards-compatible with 
 .B ncap
 which is now deprecated.
 Both operators arithmetically process netCDF files.

--- a/src/nco/nco_fl_utl.c
+++ b/src/nco/nco_fl_utl.c
@@ -433,7 +433,7 @@ nco_fl_lst_mk /* [fnc] Create file list from command line positional arguments *
 	   3. \n allows entries to be separated by carriage returns */
 	while(((cnv_nbr=fscanf(fp_in,fmt_sng,bfr_in)) != EOF) && (fl_lst_in_lng < FL_LST_IN_MAX_LNG)){
 	  if(cnv_nbr == 0){
-	    (void)fprintf(stdout,"%s: ERROR stdin input not convertable to filename. HINT: Maximum length for input filenames is %d characters. HINT: Separate filenames with whitespace. Carriage returns are automatically stripped out.\n",nco_prg_nm_get(),FL_NM_IN_MAX_LNG);
+	    (void)fprintf(stdout,"%s: ERROR stdin input not convertible to filename. HINT: Maximum length for input filenames is %d characters. HINT: Separate filenames with whitespace. Carriage returns are automatically stripped out.\n",nco_prg_nm_get(),FL_NM_IN_MAX_LNG);
 	    nco_exit(EXIT_FAILURE);
 	  } /* endif err */
 	  fl_nm_lng=strlen(bfr_in);


### PR DESCRIPTION
The lintian QA tool reported a couple of spelling errors for 4.6.2:

 * convertable -> convertible
 * supercedes  -> supersedes

If you'd like to catch these before the release, I recommend to modify the spelling script from GDAL for NCO:

 https://trac.osgeo.org/gdal/browser/trunk/gdal/scripts/fix_typos.sh