### PR TITLE
Add ncap_yacc.h to BUILT_SOURCES to build it before being used.

### DIFF
--- a/src/nco/Makefile.am
+++ b/src/nco/Makefile.am
@@ -26,6 +26,8 @@ else
 bin_PROGRAMS = ${NCAP} ncatted ncbo ncecat ncflint ncks ncpdq ncra ncrename ${NCWA}
 endif
 
+BUILT_SOURCES = ncap_yacc.h
+
 AM_YFLAGS = -d --name-prefix=nco_yy
 
 ncap_SOURCES = ncap_utl.c ncap.c ncap_yacc.y ncap_lex.l


### PR DESCRIPTION
To fix the issue reported in #40 where the build failed when `-j64` was used because `ncap_yacc.h` is used before being generated, I found the `BUILT_SOURCES` solution in the automake documentation, see:

 https://www.gnu.org/software/automake/manual/html_node/Yacc-and-Lex.html
 https://www.gnu.org/software/automake/manual/html_node/Sources.html