### PR TITLE
Update the ncks rgr Flag Parsing

### DIFF
--- a/bm/NCO_rgr.pm
+++ b/bm/NCO_rgr.pm
@@ -2965,10 +2965,10 @@ if($RUN_NETCDF4_TESTS_VERSION_GE_431){
     $#tst_cmd=0; # Reset array
 
 # ncks #122
-# ncks -h -O $nco_D_flg --gaa foo,boo=bar#foo2,foo3=bar2#--no_area_out#foo3,foo4='Thu Sep 15 13:03:18 PDT 2016'#foo5,foo6=bar4 $in_pth_arg in.nc %tmp_fl_00%
+# ncks -h -O --rgr grid=~/foo_grid.nc#latlon=64,128#--no_area#lat_typ=gss#lon_typ=Grn_ctr ~/nco/data/in.nc ~/foo.nc
 # ncks -M ~/foo.nc | grep foo6 | cut -d ' ' -f 11
     $dsc_sng="Multi-argument parsing test when has a flag in it";
-    $tst_cmd[0]="ncks -h -O $nco_D_flg --gaa foo,boo=bar#foo2,foo3=bar2#--no_area_out#foo3,foo4='Thu Sep 15 13:03:18 PDT 2016'#foo5,foo6=bar4 $in_pth_arg in.nc %tmp_fl_00%";
+    $tst_cmd[0]="grid=~/foo_grid.nc#latlon=64,128#--no_area#lat_typ=gss#lon_typ=Grn_ctr $in_pth_arg in.nc %tmp_fl_00%";
     $tst_cmd[1]="ncks -M %tmp_fl_00% | grep foo6 | cut -d ' ' -f 11";
     $tst_cmd[2]="bar4";
     $tst_cmd[3]="SS_OK";   

--- a/bm/NCO_rgr.pm
+++ b/bm/NCO_rgr.pm
@@ -2964,6 +2964,17 @@ if($RUN_NETCDF4_TESTS_VERSION_GE_431){
     NCO_bm::tst_run(\@tst_cmd);
     $#tst_cmd=0; # Reset array
 
+# ncks #122
+# ncks -h -O $nco_D_flg --gaa foo,boo=bar#foo2,foo3=bar2#--no_area_out#foo3,foo4='Thu Sep 15 13:03:18 PDT 2016'#foo5,foo6=bar4 $in_pth_arg in.nc %tmp_fl_00%
+# ncks -M ~/foo.nc | grep foo6 | cut -d ' ' -f 11
+    $dsc_sng="Multi-argument parsing test when has a flag in it";
+    $tst_cmd[0]="ncks -h -O $nco_D_flg --gaa foo,boo=bar#foo2,foo3=bar2#--no_area_out#foo3,foo4='Thu Sep 15 13:03:18 PDT 2016'#foo5,foo6=bar4 $in_pth_arg in.nc %tmp_fl_00%";
+    $tst_cmd[1]="ncks -M %tmp_fl_00% | grep foo6 | cut -d ' ' -f 11";
+    $tst_cmd[2]="bar4";
+    $tst_cmd[3]="SS_OK";   
+    NCO_bm::tst_run(\@tst_cmd);
+    $#tst_cmd=0; # Reset array
+
 #####################
 #### ncpdq tests #### -OK !
 #####################

--- a/bm/NCO_rgr.pm
+++ b/bm/NCO_rgr.pm
@@ -2965,10 +2965,10 @@ if($RUN_NETCDF4_TESTS_VERSION_GE_431){
     $#tst_cmd=0; # Reset array
 
 # ncks #122
-# ncks -h -O --rgr grid=~/foo_grid.nc#latlon=64,128#--no_area#lat_typ=gss#lon_typ=Grn_ctr ~/nco/data/in.nc ~/foo.nc
+# ncks -O --rgr grid=~/foo_grid.nc#latlon=64,128#--no_area#lat_typ=gss#lon_typ=Grn_ctr ~/nco/data/in.nc ~/foo.nc
 # ncks -M ~/foo.nc | grep foo6 | cut -d ' ' -f 11
     $dsc_sng="Multi-argument parsing test when has a flag in it";
-    $tst_cmd[0]="grid=~/foo_grid.nc#latlon=64,128#--no_area#lat_typ=gss#lon_typ=Grn_ctr $in_pth_arg in.nc %tmp_fl_00%";
+    $tst_cmd[0]="ncks -O --rgr grid=~/foo_grid.nc#latlon=64,128#--no_area#lat_typ=gss#lon_typ=Grn_ctr $in_pth_arg in.nc %tmp_fl_00%";
     $tst_cmd[1]="ncks -M %tmp_fl_00% | grep foo6 | cut -d ' ' -f 11";
     $tst_cmd[2]="bar4";
     $tst_cmd[3]="SS_OK";   

--- a/src/nco/nco_att_utl.c
+++ b/src/nco/nco_att_utl.c
@@ -1976,7 +1976,11 @@ nco_glb_att_add /* [fnc] Add global attributes */
     gaa_aed.type=NC_CHAR;
     /* Insert value into attribute structure */
     gaa_aed.val=att_val;
-    gaa_aed.sz=strlen(gaa_aed.val.cp);
+    /* 20170428 jm: Update for flag parsing*/
+    if(gaa_aed.val.cp)
+      gaa_aed.sz=strlen(gaa_aed.val.cp);
+    else
+      gaa_aed.sz=0;
     /* 20160324: which is better mode for gaa---overwrite or append? 
        20160330: answer is overwrite. otherwise, climo_nco.sh produces ANN file with, e.g.,
        :climo_script = "climo_nco.shclimo_nco.shclimo_nco.sh" ;

--- a/src/nco/nco_mta.c
+++ b/src/nco/nco_mta.c
@@ -112,7 +112,9 @@ nco_remove_hyphens /* [fnc] Remove the hyphens come before the flag */
     int absolute_pos=hyphen_pos-args;/* Get memory address offset */
     memmove(&args[absolute_pos],&args[absolute_pos+1L],strlen(args)-absolute_pos);
     return nco_remove_hyphens(args);
-  }else return args;
+  }
+  else
+    return args;
 }
 
 char ** /* O [sng] Group of split strings */
@@ -284,15 +286,16 @@ nco_arg_mlt_prs /* [fnc] main parser, split the string and assign to kvm structu
     }
     else
     { /*Pure key case (flags) */
-      value=strdup(nco_remove_hyphens(separate_args[sng_idx]));
-      set_of_keys=strdup(value);
+      set_of_keys=strdup(nco_remove_hyphens(separate_args[sng_idx]));
+      value=NULL;
     }
     char **individual_args=nco_sng_split(set_of_keys,nco_mta_sub_dlm);
     
     for(int sub_idx=0;sub_idx<nco_count_blocks(set_of_keys,nco_mta_sub_dlm);sub_idx++){
       char *temp_value=strdup(individual_args[sub_idx]);
-      temp_value=(char *)nco_realloc(temp_value,strlen(temp_value)+strlen(value)+1L);
-      temp_value=strcat(temp_value,value);
+      temp_value=(char *)nco_realloc(temp_value,strlen(temp_value)+(value ? strlen(value) : 0)+1L);
+      if(value)
+        temp_value= strcat(temp_value,value);
       kvm_set[kvm_idx++]=nco_sng2kvm(nco_remove_backslash(temp_value));
       nco_free(temp_value);
     } /* !sub_idx */

--- a/src/nco/nco_mta.c
+++ b/src/nco/nco_mta.c
@@ -176,19 +176,18 @@ int /* O [bool] boolean for whether it is a ncks flag */
 nco_is_flag /* [fnc] Check whether the input is a ncks flag*/
 (const char* flag) /* I [sng] Input string */
 {
-    const char *rgr_flags[] ={"--no_area",
-                              "--no_area_out",
-                              "--cell_measures",
-                              "--cll_msr",
-                              "--no_cell_measures",
-                              "--no_cll_msr",
-                              "--curvilinear",
-                              "--crv",
-                              "--crv",
-                              "--infer",
-                              "-nfr",
-                              "--no_stagger",
-                              "--no_stg"};
+    const char *rgr_flags[] ={"no_area",
+                              "no_area_out",
+                              "cell_measures",
+                              "cll_msr",
+                              "no_cell_measures",
+                              "no_cll_msr",
+                              "curvilinear",
+                              "crv",
+                              "infer",
+                              "nfr",
+                              "no_stagger",
+                              "no_stg"};
     const char *gaa_flags[] ={""};
     const char *trr_flags[] ={""};
     const char *ppc_flags[] ={""};
@@ -214,9 +213,35 @@ nco_is_flag /* [fnc] Check whether the input is a ncks flag*/
       if(!strcmp(flag, ppc_flags[index])) 
         return NCO_NOERR;
     }
+
+    (void)fprintf(stderr, "ERROR: Possibly you mistyped a flag. HINT If you are trying to use a (or multiple) ncks flag(s), please refer to the following lists of ncks flags  dand make sure that you correct any typos. The flag(s) can be Linux style (with \"--\") or concise style (w/o \"--\")\n");
+
+    (void)fprintf(stderr, "ncks rgr (Regridding) flags:\n");
+    for(int index=0;index<sizeof(rgr_flags)/sizeof(char*);index++)
+    {
+     (void)fprintf(stderr, "  %2d. %s\n",index+1,rgr_flags[index]);
+    }
+    (void)fprintf(stderr, "ncks gaa (Global Attribute Adding) flags:\n");
+    for(int index=0;index<sizeof(gaa_flags)/sizeof(char*);index++)
+    {
+      (void)fprintf(stderr, "%s\n",gaa_flags[index]);
+    }
+
+    (void)fprintf(stderr, "ncks trr (Terraref) flags:\n");
+    for(int index=0;index<sizeof(trr_flags)/sizeof(char*);index++)
+    {
+      (void)fprintf(stderr, "%s\n",trr_flags[index]);
+    }
+    (void)fprintf(stderr, "ncks ppc (Precision-Preserving Compression) flags:\n");
+    for(int index=0;index<sizeof(ppc_flags)/sizeof(char*);index++)
+    {
+      (void)fprintf(stderr, "%s\n",ppc_flags[index]);
+    }
+
     return NCO_ERR;
 
 }
+
 
 int /* O [flg] Input has valid syntax */
 nco_input_check /* [fnc] Check whether input has valid syntax */
@@ -227,10 +252,13 @@ nco_input_check /* [fnc] Check whether input has valid syntax */
   const char fnc_nm[]="nco_input_check()"; /* [sng] Function name */
 
   if(!strstr(args,"=")){ // If no equal sign in arguments
-    if(!nco_is_flag(args)){
+    char* arg_copy=strdup(args);
+    if(!nco_is_flag(nco_remove_hyphens(arg_copy))){
       (void)fprintf(stderr,"%s: ERROR %s did not detect equal sign between key and value for argument \"%s\".\n%s HINT This can occur when the designated or default key-value delimiter \"%s\" is mixed into the literal text of the value. Try changing the delimiter to a string guaranteed not to appear in the value string with, e.g., --dlm=\"##\".\n",nco_prg_nm_get(),fnc_nm,args,nco_prg_nm_get(),nco_mta_dlm_get());
+      nco_free(arg_copy);
       return NCO_ERR;
     }
+    nco_free(arg_copy);
   }
   if(strstr(args,"=") == args){ // Equal sign is at argument start (no key)
     (void)fprintf(stderr,"%s: ERROR %s reports no key in key-value pair for argument \"%s\".\n%s HINT It appears that an equal sign is the first character of the argument, meaning that a value was specified with a corresponding key.\n",nco_prg_nm_get(),fnc_nm,args,nco_prg_nm_get()); 

--- a/src/nco/nco_mta.h
+++ b/src/nco/nco_mta.h
@@ -49,9 +49,9 @@ extern "C" {
   nco_kvm_prn /* [fnc] Print kvm contents */
   (kvm_sct kvm); /* [fnc] kvm to print */
 
-  char *
-  nco_remove_backslash
-  (char* args);
+  char * /* O [sng] the flag that has no hyphens */
+  nco_remove_hyphens /* [fnc] Remove the hyphens come before the flag */
+  (char* args); /* I [sng] the flag that has hyphens in it*/
 
   char ** /* O [sng] Group of split strings */
   nco_sng_split /* [fnc] Split string by delimiter */


### PR DESCRIPTION
Now the ncks can normally parse the flags and the users do not need to add redundant values for them, e.g.,
```bash
ncks -O --rgr grid=~/foo_grid.nc#latlon=64,128#--no_area#lat_typ=gss#lon_typ=Grn_ctr ~/nco/data/in.nc ~/foo.nc
```
is considered as a legal input (notice the flag "--no_area").

@czender 
Please help update the testcase in [NCO_rgr.pm](https://github.com/FlyingWithJerome/nco/blob/master/bm/NCO_rgr.pm) to see whether "no_area" is a good flag we can test and how to test it. So far it can be successfully compiled and executed, but we do need to see the outputs.

The testcase is marked as "ncks #122."