### PR TITLE
fixed: GSL not recognised when GSL_LIB was set

### DIFF
--- a/configure
+++ b/configure
@@ -19691,10 +19691,8 @@ if test "${enable_gsl}" != 'no'; then
     fi
     if test "${GSL_LIB}"; then
 	LIBS="${LIBS} -L${GSL_LIB}"
-    else
-	GSL_LIB="${GSL_ROOT}/lib"
-	LIBS="${LIBS} `${GSL_CONFIG} --libs`"
     fi
+	LIBS="${LIBS} `${GSL_CONFIG} --libs`"
     { $as_echo "$as_me:${as_lineno-$LINENO}: These GSL library and header tests must succeed for GSL support:" >&5
 $as_echo "$as_me: These GSL library and header tests must succeed for GSL support:" >&6;}
 # fxm: default action of check_lib adds a superfluous -lgsl to $LIBS

--- a/configure.ac
+++ b/configure.ac
@@ -635,10 +635,8 @@ if test "${enable_gsl}" != 'no'; then
     fi
     if test "${GSL_LIB}"; then
 	LIBS="${LIBS} -L${GSL_LIB}"
-    else
-	GSL_LIB="${GSL_ROOT}/lib"
-	LIBS="${LIBS} `${GSL_CONFIG} --libs`"
     fi
+	LIBS="${LIBS} `${GSL_CONFIG} --libs`"
     AC_MSG_NOTICE([These GSL library and header tests must succeed for GSL support:])
 # fxm: default action of check_lib adds a superfluous -lgsl to $LIBS
     AC_CHECK_LIB([gsl],[gsl_sf_gamma_inc],,enable_gsl=no)


### PR DESCRIPTION
When GSL_LIB was set, "gsl-config --libs" was not called and appended
to LIBS. If GSL_LIB did not contain -lgsl but just -L/SOME/GSL/LIB/DIR,
GSL was not properly recognized. Now, GSL_LIB is appended to LIBS and,
in addition, `$GSL_ROOT/bin/gsl-config --libs` is also appended to
LIBS.