### PR TITLE
Fixed  in 4c.nc  creation

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -13,6 +13,7 @@ ACLOCAL_AMFLAGS = -I m4
 test:	tst
 tst:
 	$(MAKE) check
+	cd data && $(MAKE) in_4c.nc && cd ..
 	cd bm && ./nco_bm.pl --regress
 
 regress:	rgr

--- a/Makefile.in
+++ b/Makefile.in
@@ -859,6 +859,7 @@ uninstall-am:
 test:	tst
 tst:
 	$(MAKE) check
+	cd data && $(MAKE) in_4c.nc && cd ..
 	cd bm && ./nco_bm.pl --regress
 
 regress:	rgr

--- a/configure
+++ b/configure
@@ -19691,10 +19691,8 @@ if test "${enable_gsl}" != 'no'; then
     fi
     if test "${GSL_LIB}"; then
 	LIBS="${LIBS} -L${GSL_LIB}"
-    else
-	GSL_LIB="${GSL_ROOT}/lib"
-	LIBS="${LIBS} `${GSL_CONFIG} --libs`"
     fi
+	LIBS="${LIBS} `${GSL_CONFIG} --libs`"
     { $as_echo "$as_me:${as_lineno-$LINENO}: These GSL library and header tests must succeed for GSL support:" >&5
 $as_echo "$as_me: These GSL library and header tests must succeed for GSL support:" >&6;}
 # fxm: default action of check_lib adds a superfluous -lgsl to $LIBS

--- a/configure.ac
+++ b/configure.ac
@@ -635,10 +635,8 @@ if test "${enable_gsl}" != 'no'; then
     fi
     if test "${GSL_LIB}"; then
 	LIBS="${LIBS} -L${GSL_LIB}"
-    else
-	GSL_LIB="${GSL_ROOT}/lib"
-	LIBS="${LIBS} `${GSL_CONFIG} --libs`"
     fi
+	LIBS="${LIBS} `${GSL_CONFIG} --libs`"
     AC_MSG_NOTICE([These GSL library and header tests must succeed for GSL support:])
 # fxm: default action of check_lib adds a superfluous -lgsl to $LIBS
     AC_CHECK_LIB([gsl],[gsl_sf_gamma_inc],,enable_gsl=no)

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -9,7 +9,7 @@ test_data_netCDF4 = in_4c.nc in_grp.nc in_grp_1.nc in_grp_2.nc in_grp_3.nc in_gr
 	-@PATH_TO_NCGEN@ -o $@ $< 
 
 in_4c.nc : in.cdl
-	-ncks -O -7 --cnk_dmn time,10 in.nc $@
+	-@abs_top_builddir@/src/nco/ncks -O -7 --cnk_dmn time,10 in.nc $@
 # ncgen default chunksize for time = 4 MB produces ~200 MB in_4c.nc file. Avoid that!
 #	-@PATH_TO_NCGEN@ -k hdf5-nc3 -o $@ $< 
 

--- a/data/Makefile.in
+++ b/data/Makefile.in
@@ -559,7 +559,7 @@ uninstall-am: uninstall-dist_binSCRIPTS
 	-@PATH_TO_NCGEN@ -o $@ $< 
 
 in_4c.nc : in.cdl
-	-ncks -O -7 --cnk_dmn time,10 in.nc $@
+	-@abs_top_builddir@/src/nco/ncks -O -7 --cnk_dmn time,10 in.nc $@
 # ncgen default chunksize for time = 4 MB produces ~200 MB in_4c.nc file. Avoid that!
 #	-@PATH_TO_NCGEN@ -k hdf5-nc3 -o $@ $< 
 


### PR DESCRIPTION
test file in_4c.nc now is created during make test

The ./data directory contains *.cdl files, from which netCDF files for the NCO tests are build. The makefile for creating these files is called in the beginning of the build process. However, creating the file in_4c.nc needs 'ncks'. All other files are generated via 'ncgen'. Because ncks has not been compiled in the beginning of the build process, that file is not generated/created. Two makefiles were modified:

1) `./data/Makefile`: path to the compiled ncks binary (path BEFORE 'make install') -> `$abs_top_builddir/src/nco/ncks`

2) `./Makefile`: the 'tst' target now does `> cd data && $(MAKE) in_4c.nc && cd ..` to generate the 'in_4c.nc' before the actual tests are performed

The Makefile.in and Makefile.am were equally modified (one doesn't need to newly generate the Makefile.in files).)
