### PR TITLE
Add AppVeyor+conda builds/tests.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,38 @@
+environment:
+  matrix:
+    - TARGET_ARCH: x64
+      CONDA_PY: 36
+      CONDA_INSTALL_LOCN: C:\\Miniconda36-x64
+
+platform:
+  - x64
+
+install:
+  # If there is a newer build queued for the same PR, cancel this one.
+  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
+        https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
+        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
+        throw "There are newer queued builds for this pull request, failing early." }
+
+  - cmd: rmdir C:\cygwin /s /q
+
+  # Add path, activate `conda` and update conda.
+  - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
+
+  # # Add path, activate `conda` and update conda.
+  - cmd: conda config --set always_yes yes --set changeps1 no --set show_channel_urls true
+  - cmd: conda update conda
+  - cmd: conda config --prepend channels conda-forge
+
+  - cmd: set PYTHONUNBUFFERED=1
+
+  - cmd: conda install conda-build
+  - cmd: conda info --all
+  - cmd: conda list
+
+
+# Skip .NET project specific build phase.
+build: off
+
+test_script:
+  - "conda build conda.recipe"

--- a/conda.recipe/bld.bat
+++ b/conda.recipe/bld.bat
@@ -1,0 +1,34 @@
+mkdir %SRC_DIR%\build
+cd %SRC_DIR%\build
+
+set "CFLAGS=%CFLAGS% -DWIN32 -DGSL_DLL"
+set "CXXFLAGS=%CXXFLAGS% -DWIN32 -DGSL_DLL"
+
+cmake -G "NMake Makefiles" ^
+      -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+      -D CMAKE_BUILD_TYPE=Release ^
+      -D NCO_MSVC_USE_MT=no ^
+      -D CMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
+      -D NETCDF_INCLUDE=%LIBRARY_INC% ^
+      -D NETCDF_LIBRARY=%LIBRARY_LIB%\netcdf.lib ^
+      -D HDF5_LIBRARY=%LIBRARY_LIB%\libhdf5.lib ^
+      -D HDF5_HL_LIBRARY=%LIBRARY_LIB%\libhdf5_hl.lib ^
+      -D GSL_INCLUDE=%LIBRARY_INC% ^
+      -D GSL_LIBRARY=%LIBRARY_LIB%\gsl.lib ^
+      -D GSL_CBLAS_LIBRARY=%LIBRARY_LIB%\gslcblas.lib ^
+      -D UDUNITS2_INCLUDE=%LIBRARY_LIB% ^
+      -D UDUNITS2_LIBRARY=%LIBRARY_LIB%\udunits2.lib ^
+      -D EXPAT_LIBRARY=%LIBRARY_LIB%\expat.lib ^
+      -D CURL_LIBRARY=%LIBRARY_LIB%\libcurl.lib ^
+      -D ANTLR_INCLUDE:PATH=%LIBRARY_INC%\antlr ^
+      %SRC_DIR%
+if errorlevel 1 exit 1
+
+
+nmake
+if errorlevel 1 exit 1
+
+nmake install
+if errorlevel 1 exit 1
+
+move %LIBRARY_PREFIX%\*.exe %LIBRARY_BIN% || exit 1

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,0 +1,43 @@
+{% set version = "dev" %}
+
+package:
+  name: nco
+  version: {{ version }}
+
+source:
+  path: ../
+
+build:
+  number: 0
+  features:
+    - vc14
+
+requirements:
+  build:
+    - python
+    - cmake
+    - antlr >=2.7.7,<3
+    - curl >=7.44.0,<8
+    - expat 2.2.*
+    - gsl >=2.2,<2.3
+    - hdf5 1.10.1
+    - libnetcdf 4.4.*
+    - udunits2
+    - zlib 1.2.11
+    - vc 14
+  run:
+    - curl >=7.44.0,<8
+    - expat 2.2.*
+    - gsl >=2.2,<2.3
+    - hdf5 1.10.1
+    - libnetcdf 4.4.*
+    - udunits2
+    - vc 14
+
+test:
+  source_files:
+    - data/in.cdl
+  commands:
+    - ncks --help
+    - ncap2 --help
+    - ncks -M "http://tds.marine.rutgers.edu/thredds/dodsC/roms/espresso/2013_da/his/ESPRESSO_Real-Time_v2_History_Best"

--- a/conda.recipe/run_test.bat
+++ b/conda.recipe/run_test.bat
@@ -1,0 +1,7 @@
+cd data
+
+ncgen -o in.nc in.cdl || exit 1
+
+ncks -H --trd -v one in.nc || exit 1
+
+ncap2 -O -v -s 'erf_one=float(gsl_sf_erf(1.0f));print(erf_one,"%g")' in.nc foo.nc || exit 1


### PR DESCRIPTION
@czender this adds a simple AppVeyor configuration that builds the conda recipe for Windows and run the same tests from the `conda-forge` feedstock. It can serve as a guide to catch bugs early as you develop `nco`. Note that you will need to enable AppVeyor for this repository to see the status in each PRs.

Right not the command `ccap2 -O -v -s 'erf_one=float(gsl_sf_erf(1.0f));print(erf_one,"%g")' in.nc foo.nc` is failing. A user reported that as soon as I published the Windows binaries :unamused: 

I added the `|| exit 1` to prevent AppVeyor from failing silently but, because this is a segfault, so we don't get much info on the screen. I made the same change in the conda-forge recipe in https://github.com/conda-forge/nco-feedstock/pull/55

I am not sure if that failure in in conda's `gsl` or in `nco`. I'll try to investigate more.

PS: users reported that the basic `ncks` functionalities are working properly!