### PR TITLE
fix ncap2 test on windows

### DIFF
--- a/conda.recipe/run_test.bat
+++ b/conda.recipe/run_test.bat
@@ -4,4 +4,5 @@ ncgen -o in.nc in.cdl || exit 1
 
 ncks -H --trd -v one in.nc || exit 1
 
-ncap2 -O -v -s 'erf_one=float(gsl_sf_erf(1.0f));print(erf_one,"%g")' in.nc foo.nc || exit 1
+ncap2 -O -v -s "erf_one=float(gsl_sf_erf(1.0f));" in.nc foo.nc || exit 1
+ncks -v erf_one foo.nc || exit 1


### PR DESCRIPTION
This PR fixes the Windows `ncap2` test by avoiding the `print`, replacing `'` with `"` and checking the expected value with `ncks`. Ideally we should check if the value is indeed 0.8427008 but my Windows CLI-fu is terrible and I have no idea how to do it.

PS: the change here is the same as https://github.com/conda-forge/nco-feedstock/pull/55/commits/be01a370f6e24c5c16f3c261d92b72eb28e99a60