### PR TITLE
Create sanitize_input branch. Implement nco_sng_sntz().

### DIFF
--- a/bm/NCO_bm.pm
+++ b/bm/NCO_bm.pm
@@ -686,7 +686,7 @@ sub tst_run {
 	    $cmd_lst_cnt++;
 	    if ($dbg_lvl > 2) {
 		print "\ntst_run: test cycle held - hit <Enter> to continue\n";
-		my $wait = <STDIN>;
+		#		my $wait = <STDIN>;
 	    }
 	} # end loop: 	foreach (@cmd_lst)
     } # end of client side 'else'

--- a/bm/nco_bm.pl
+++ b/bm/nco_bm.pl
@@ -257,9 +257,7 @@ if ($os_sng =~ /Darwin/){
 	  If you want life to be better, consider installing the GNU coreutils
 	  which will provide an acceptable 'cut'.
 	  
-	  Hit <Enter> to acknowledge your miserable state of cut kharma.
 BADCUT
-        $tmp=<STDIN>;
 	$gnu_cut=0;
     }
 }
@@ -427,7 +425,7 @@ if(-e "/usr/bin/time" && -x "/usr/bin/time"){
     $tmr_app="time "; # bash builtin or other 'time'-like application (AIX)
 } # endif time
 
-if($dbg_lvl > 1){
+if($dbg_lvl >= 4){
     print "\nAbout to begin requested tests; waiting for keypress to proceed.\n";
     my $tmp=<STDIN>;
 }

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,5 +1,7 @@
 2018-02-27  Charlie Zender  <zender@uci.edu>
 
+	* White-list forward slash on Windows so URLs are acceptable (http://...)
+
 	* Make sure single file operator input is sanitized
 
 2018-02-22  Charlie Zender  <zender@uci.edu>

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,5 +1,9 @@
 2018-02-22  Charlie Zender  <zender@uci.edu>
 
+	* Protect MSVC backslash
+
+	* Do not call sanitizer on system memory
+
 	* White-list percent sign (NCO regression test uses, e.g., %tmp_fl_00)
 
 	* Eliminate waiting on user input for regression tests

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,3 +1,7 @@
+2018-02-27  Charlie Zender  <zender@uci.edu>
+
+	* Make sure single file operator input is sanitized
+
 2018-02-22  Charlie Zender  <zender@uci.edu>
 
 	* Protect MSVC backslash

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,3 +1,13 @@
+2018-02-22  Charlie Zender  <zender@uci.edu>
+
+	* White-list percent sign (NCO regression test uses, e.g., %tmp_fl_00)
+
+	* Eliminate waiting on user input for regression tests
+
+	* Implement nco_sng_sntz(), notice 13 new ncks regressions
+
+	* Create sanitize_input branch
+
 2018-02-21  Charlie Zender  <zender@uci.edu>
 
 	* NCO 4.7.3-alpha05 release procedure:

--- a/doc/nco.texi
+++ b/doc/nco.texi
@@ -13522,12 +13522,13 @@ temp_avg.ram_write();           // Write Variable to output
 @node Where statement, Loops, RAM variables, ncap2 netCDF Arithmetic Processor
 @subsection Where statement
 @cindex where()
-A @code{where()} combines the definition and application of a mask all in one go and can lead to succinct code. 
+A @code{where()} combines the definition and application of a mask all
+in one go and can lead to succinct code.  
 The full syntax of a @code{where()} statement is as follows:
 
 @example
 @verbatim
-// Single assign (the 'elsewhere' block is optional)
+// Single assign ('elsewhere' is optional)
 where(mask) 
    var1=expr1;
 elsewhere

--- a/src/nco/nco_fl_utl.c
+++ b/src/nco/nco_fl_utl.c
@@ -383,7 +383,6 @@ nco_fl_lst_mk /* [fnc] Create file list from command line positional arguments *
   /* Might there be problems with any specified files? */
   for(idx=arg_crr;idx<argc;idx++){
     if((int)strlen(argv[idx]) >= fl_nm_sz_wrn) (void)fprintf(stderr,"%s: WARNING filename %s is very long (%ld characters) and may not be portable to older operating systems\n",nco_prg_nm_get(),argv[idx],(long int)strlen(argv[idx]));
-    (void)nco_sng_sntz(argv[idx]);
   } /* end loop over idx */
 
   /* All operators except multi-file operators must have at least one positional argument */
@@ -539,7 +538,7 @@ nco_fl_lst_mk /* [fnc] Create file list from command line positional arguments *
     nco_exit(EXIT_FAILURE);
   } /* end if */
 
-  /* Sanitize input list from stdin or from positional arguments */
+  /* Sanitize input list from stdin and from positional arguments */
   for(int fl_idx=0;fl_idx<*fl_nbr;fl_idx++) (void)nco_sng_sntz(fl_lst_in[fl_idx]);
 
   /* Assign output file from positional argument */

--- a/src/nco/nco_fl_utl.c
+++ b/src/nco/nco_fl_utl.c
@@ -383,6 +383,7 @@ nco_fl_lst_mk /* [fnc] Create file list from command line positional arguments *
   /* Might there be problems with any specified files? */
   for(idx=arg_crr;idx<argc;idx++){
     if((int)strlen(argv[idx]) >= fl_nm_sz_wrn) (void)fprintf(stderr,"%s: WARNING filename %s is very long (%ld characters) and may not be portable to older operating systems\n",nco_prg_nm_get(),argv[idx],(long int)strlen(argv[idx]));
+    (void)nco_sng_sntz(argv[idx]);
   } /* end loop over idx */
 
   /* All operators except multi-file operators must have at least one positional argument */
@@ -538,9 +539,15 @@ nco_fl_lst_mk /* [fnc] Create file list from command line positional arguments *
     nco_exit(EXIT_FAILURE);
   } /* end if */
 
-  /* Assign output file from positional argument */
-  if(FL_OUT_FROM_PSN_ARG) *fl_out=(char *)strdup(argv[argc-1]);
+  /* Sanitize input list from stdin or from positional arguments */
+  for(int fl_idx=0;fl_idx<*fl_nbr;fl_idx++) (void)nco_sng_sntz(fl_lst_in[fl_idx]);
 
+  /* Assign output file from positional argument */
+  if(FL_OUT_FROM_PSN_ARG){
+    *fl_out=(char *)strdup(argv[argc-1]);
+    *fl_out=nco_sng_sntz(*fl_out);
+  } /* !FL_OUT_FROM_PSN_ARG */
+ 
   return fl_lst_in;
 
 } /* end nco_fl_lst_mk() */

--- a/src/nco/nco_fl_utl.c
+++ b/src/nco/nco_fl_utl.c
@@ -405,8 +405,15 @@ nco_fl_lst_mk /* [fnc] Create file list from command line positional arguments *
     } /* end if */
     fl_lst_in=(char **)nco_malloc(sizeof(char *)); /* fxm: free() this memory sometime */
     fl_lst_in[(*fl_nbr)++]=(char *)strdup(argv[arg_crr++]);
+
+    /* Sanitize input list from stdin and from positional arguments */
+    for(int fl_idx=0;fl_idx<*fl_nbr;fl_idx++) (void)nco_sng_sntz(fl_lst_in[fl_idx]);
+
     /* Output file is optional for these operators */
-    if(arg_crr == argc-1) *fl_out=(char *)strdup(argv[arg_crr]);
+    if(arg_crr == argc-1){
+      *fl_out=(char *)strdup(argv[arg_crr]);
+      *fl_out=nco_sng_sntz(*fl_out);
+    } /* !arg_crr */
     return fl_lst_in;
     /* break; *//* NB: break after return in case statement causes SGI cc warning */
   case ncbo:

--- a/src/nco/nco_sng_utl.c
+++ b/src/nco/nco_sng_utl.c
@@ -790,26 +790,26 @@ nco_sng_sntz /* [fnc] Ensure input string contains only white-listed innocuous c
 #ifndef _MSC_VER
     "/";
 #else /* !_MSC_VER */
-    "\";
+  "\\";
 #endif /* !_MSC_VER */
   /* ": re-balance syntax highlighting */
 
-    char *usr_dta=sng_drt;
-    char *cp=usr_dta; /* Cursor into string */
+  char *usr_dta=sng_drt;
+  char *cp=usr_dta; /* Cursor into string */
+  
+  if(nco_dbg_lvl_get() >= nco_dbg_fl) (void)fprintf(stderr,"%s: DEBUG %s reports unsanitized usr_dta = %s\n",nco_prg_nm_get(),fnc_nm,usr_dta);
 
-    if(nco_dbg_lvl_get() >= nco_dbg_fl) (void)fprintf(stderr,"%s: DEBUG %s reports unsanitized usr_dta = %s\n",nco_prg_nm_get(),fnc_nm,usr_dta);
+  const char *sng_end=usr_dta+strlen(usr_dta);
+  for(cp+=strspn(cp,wht_lst);cp!=sng_end;cp+=strspn(cp,wht_lst)){
+    (void)fprintf(stderr,"%s: ERROR %s reports character \'%c\' from unsanitized user-input string \"%s\" is not on whitelist of acceptable characters. For security purposes NCO restricts the set of characters appearing in user input, including filenames, to: \"%s\". NB: This restriction was first imposed in NCO 4.7.3 (February, 2018), and may cause breakage of older workflows. Please contact NCO if you have a real-world use-case that shows why the character \'%c\' should be white-listed. HINT: Re-try command after replacing transgressing characters with innocuous characters.\n",nco_prg_nm_get(),fnc_nm,*cp,usr_dta,wht_lst,*cp);
+    /* Uncomment next two lines to sanitize unsafe character with an underscore
+     *cp='_';
+     if(nco_dbg_lvl_get() >= nco_dbg_fl) (void)fprintf(stderr,"%s: DEBUG %s reports sanitized usr_dta = %s\n",nco_prg_nm_get(),fnc_nm,usr_dta); */
 
-    const char *sng_end=usr_dta+strlen(usr_dta);
-    for(cp+=strspn(cp,wht_lst);cp!=sng_end;cp+=strspn(cp,wht_lst)){
-      (void)fprintf(stderr,"%s: ERROR %s reports character \'%c\' from unsanitized user-input string \"%s\" is not on whitelist of acceptable characters. For security purposes NCO restricts the set of characters appearing in user input, including filenames, to: \"%s\". NB: This restriction was first imposed in NCO 4.7.3 (February, 2018), and may cause breakage of older workflows. Please contact NCO if you have a real-world use-case that shows why the character \'%c\' should be white-listed. HINT: Re-try command after replacing transgressing characters with innocuous characters.\n",nco_prg_nm_get(),fnc_nm,*cp,usr_dta,wht_lst,*cp);
-      /* Uncomment next two lines to sanitize unsafe character with an underscore
-         *cp='_';
-	 if(nco_dbg_lvl_get() >= nco_dbg_fl) (void)fprintf(stderr,"%s: DEBUG %s reports sanitized usr_dta = %s\n",nco_prg_nm_get(),fnc_nm,usr_dta); */
+    /* Provide escape route so newly broken workflows will still work with -D 73
+       Eliminate back-door after a few new versions of NCO, e.g., by version 4.7.5 */
+    if(nco_dbg_lvl_get() != 73) nco_exit(EXIT_FAILURE);
+  } /* !cp */
 
-      /* Provide escape route so newly broken workflows will still work with -D 73
-	 Eliminate back-door after a few new versions of NCO, e.g., by version 4.7.5 */
-      if(nco_dbg_lvl_get() != 73) nco_exit(EXIT_FAILURE);
-    } /* !cp */
-
-    return usr_dta;
+  return usr_dta;
 } /* !nco_sng_sntz() */

--- a/src/nco/nco_sng_utl.c
+++ b/src/nco/nco_sng_utl.c
@@ -768,3 +768,48 @@ nco_sng2typ /* [fnc] Convert user-supplied string to netCDF type enum */
 
 } /* end nco_sng2typ() */
 
+char * /* O [sng] Sanitized string */
+nco_sng_sntz /* [fnc] Ensure input string contains only white-listed innocuous characters */
+(char * const sng_drt) /* I [sng] String to sanitize */
+{
+  const char fnc_nm[]="nco_sng_sntz()"; /* [sng] Function name */
+    
+  /* Whitelist algorithm based on:
+     https://wiki.sei.cmu.edu/confluence/display/c/STR02-C.+Sanitize+data+passed+to+complex+subsystems 
+     NCO modifications to CMU default whitelist:
+     20180214: White-list colon (WRF filenames sometimes have timestamps with colons, Windows drive labels have colons) 
+     20180214: White-list space (Methinks some Windows people do have data files with spaces)
+     20180214: White-list forward slash on UNIX, backslash on Windows (path separators) 
+     20180222: White-list percent sign (NCO regression test uses, e.g., %tmp_fl_00)
+     Crucial characters that are implicitly blacklisted (and could be transformed into underscores) are:
+     ";|<>[](),*&" */
+  static char wht_lst[]="abcdefghijklmnopqrstuvwxyz"
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    "1234567890_-.@"
+    " :%"
+#ifndef _MSC_VER
+    "/";
+#else /* !_MSC_VER */
+    "\";
+#endif /* !_MSC_VER */
+  /* ": re-balance syntax highlighting */
+
+    char *usr_dta=sng_drt;
+    char *cp=usr_dta; /* Cursor into string */
+
+    if(nco_dbg_lvl_get() >= nco_dbg_fl) (void)fprintf(stderr,"%s: DEBUG %s reports unsanitized usr_dta = %s\n",nco_prg_nm_get(),fnc_nm,usr_dta);
+
+    const char *sng_end=usr_dta+strlen(usr_dta);
+    for(cp+=strspn(cp,wht_lst);cp!=sng_end;cp+=strspn(cp,wht_lst)){
+      (void)fprintf(stderr,"%s: ERROR %s reports character \'%c\' from unsanitized user-input string \"%s\" is not on whitelist of acceptable characters. For security purposes NCO restricts the set of characters appearing in user input, including filenames, to: \"%s\". NB: This restriction was first imposed in NCO 4.7.3 (February, 2018), and may cause breakage of older workflows. Please contact NCO if you have a real-world use-case that shows why the character \'%c\' should be white-listed. HINT: Re-try command after replacing transgressing characters with innocuous characters.\n",nco_prg_nm_get(),fnc_nm,*cp,usr_dta,wht_lst,*cp);
+      /* Uncomment next two lines to sanitize unsafe character with an underscore
+         *cp='_';
+	 if(nco_dbg_lvl_get() >= nco_dbg_fl) (void)fprintf(stderr,"%s: DEBUG %s reports sanitized usr_dta = %s\n",nco_prg_nm_get(),fnc_nm,usr_dta); */
+
+      /* Provide escape route so newly broken workflows will still work with -D 73
+	 Eliminate back-door after a few new versions of NCO, e.g., by version 4.7.5 */
+      if(nco_dbg_lvl_get() != 73) nco_exit(EXIT_FAILURE);
+    } /* !cp */
+
+    return usr_dta;
+} /* !nco_sng_sntz() */

--- a/src/nco/nco_sng_utl.c
+++ b/src/nco/nco_sng_utl.c
@@ -797,14 +797,14 @@ nco_sng_sntz /* [fnc] Ensure input string contains only white-listed innocuous c
   char *usr_dta=sng_drt;
   char *cp=usr_dta; /* Cursor into string */
   
-  if(nco_dbg_lvl_get() >= nco_dbg_fl) (void)fprintf(stderr,"%s: DEBUG %s reports unsanitized usr_dta = %s\n",nco_prg_nm_get(),fnc_nm,usr_dta);
+  if(nco_dbg_lvl_get() >= nco_dbg_io) (void)fprintf(stderr,"%s: DEBUG %s reports unsanitized usr_dta = %s\n",nco_prg_nm_get(),fnc_nm,usr_dta);
 
   const char *sng_end=usr_dta+strlen(usr_dta);
   for(cp+=strspn(cp,wht_lst);cp!=sng_end;cp+=strspn(cp,wht_lst)){
     (void)fprintf(stderr,"%s: ERROR %s reports character \'%c\' from unsanitized user-input string \"%s\" is not on whitelist of acceptable characters. For security purposes NCO restricts the set of characters appearing in user input, including filenames, to: \"%s\". NB: This restriction was first imposed in NCO 4.7.3 (February, 2018), and may cause breakage of older workflows. Please contact NCO if you have a real-world use-case that shows why the character \'%c\' should be white-listed. HINT: Re-try command after replacing transgressing characters with innocuous characters.\n",nco_prg_nm_get(),fnc_nm,*cp,usr_dta,wht_lst,*cp);
     /* Uncomment next two lines to sanitize unsafe character with an underscore
      *cp='_';
-     if(nco_dbg_lvl_get() >= nco_dbg_fl) (void)fprintf(stderr,"%s: DEBUG %s reports sanitized usr_dta = %s\n",nco_prg_nm_get(),fnc_nm,usr_dta); */
+     if(nco_dbg_lvl_get() >= nco_dbg_io) (void)fprintf(stderr,"%s: DEBUG %s reports sanitized usr_dta = %s\n",nco_prg_nm_get(),fnc_nm,usr_dta); */
 
     /* Provide escape route so newly broken workflows will still work with -D 73
        Eliminate back-door after a few new versions of NCO, e.g., by version 4.7.5 */

--- a/src/nco/nco_sng_utl.c
+++ b/src/nco/nco_sng_utl.c
@@ -781,17 +781,17 @@ nco_sng_sntz /* [fnc] Ensure input string contains only white-listed innocuous c
      20180214: White-list space (Methinks some Windows people do have data files with spaces)
      20180214: White-list forward slash on UNIX, backslash on Windows (path separators) 
      20180222: White-list percent sign (NCO regression test uses, e.g., %tmp_fl_00)
+     20180227: White-list forward slash on Windows so URLs are acceptable (http://...)
      Crucial characters that are implicitly blacklisted (and could be transformed into underscores) are:
      ";|<>[](),*&" */
   static char wht_lst[]="abcdefghijklmnopqrstuvwxyz"
     "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
     "1234567890_-.@"
-    " :%"
-#ifndef _MSC_VER
-    "/";
-#else /* !_MSC_VER */
-  "\\";
+    " :%/"
+#ifdef _MSC_VER
+    "\\"
 #endif /* !_MSC_VER */
+    ;
   /* ": re-balance syntax highlighting */
 
   char *usr_dta=sng_drt;

--- a/src/nco/nco_sng_utl.h
+++ b/src/nco/nco_sng_utl.h
@@ -151,6 +151,10 @@ extern "C" {
   nco_sng2typ /* [fnc] Convert user-supplied string to netCDF type enum */
   (const char * const typ_sng); /* I [sng] String indicating type */
 
+  char * /* O [sng] Sanitized string */
+  nco_sng_sntz /* [fnc] Ensure input string contains only white-listed innocuous characters */
+  (char * const sng_drt); /* I/O [sng] String to sanitize */
+
 #ifdef __cplusplus
 } /* end extern "C" */
 #endif /* __cplusplus */


### PR DESCRIPTION
Implement white-list-based filtering of input filenames. This has the potential to break existing workflows, so we may need to turn this off before release, and announce our intentions before activating. Eliminate waiting on user input for regression tests. 