### PR TITLE
fix appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,17 +28,16 @@ install:
 
   # Add path, activate `conda` and update conda.
   - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
-  - cmd: conda.exe config --set always_yes yes --set changeps1 no --set show_channel_urls true
-  - cmd: conda.exe update conda
-  - cmd: conda.exe config --remove channels defaults --force
-  - cmd: conda.exe config --add channels conda-forge --force
+  - cmd: conda config --set always_yes yes --set changeps1 no --set show_channel_urls true
+  - cmd: conda update conda
+  - cmd: conda config --remove channels defaults --force
+  - cmd: conda config --add channels conda-forge --force
   - cmd: set PYTHONUNBUFFERED=1
 
-  - cmd: conda.exe create --name TEST python=%PY% cmake antlr=2.7.7 curl expat gsl hdf5 libnetcdf udunits2 zlib
-  - cmd: conda activate TEST
+  - cmd: conda info --all
 
-  - cmd: conda.exe info --all
-  - cmd: conda.exe list
+  - cmd: conda create --name TEST python=%PY% cmake antlr=2.7.7 curl expat gsl hdf5 libnetcdf udunits2 zlib
+  - cmd: conda activate TEST
 
 # Skip .NET project specific build phase.
 build: off


### PR DESCRIPTION
This PR removes any `conda` command after the activation b/c we don't really need them. Note that AppVeyor still fails but it is a real failures now and not b/c of the `conda list/info` commands.