### PR TITLE
nco_sph_seg_parallel() - use metric to check r0, r1

### DIFF
--- a/src/nco/nco_sph.c
+++ b/src/nco/nco_sph.c
@@ -1534,15 +1534,18 @@ nco_sph_seg_parallel(double *p0, double *p1, double *q0, double *q1, double *r0,
     code='0';
   }
 
-  if(DEBUG_SPH )
-  {
+  if(DEBUG_SPH ) {
     if (code >= '1')
       nco_sph_prn_pnt("nco_sph_seg_parallel(): intersect1", r0, 3, True);
 
     if (code == '2')
       nco_sph_prn_pnt("nco_sph_seg_parallel(): intersect2", r1, 3, True);
 
+    /* points very close together - so use only first one*/
+    if (code == '2' && !nco_sph_metric(r0, r1))
+      code = '1';
   }
+
 
 
   return code;


### PR DESCRIPTION
@czender 
fixes some of the regressions of the mapping.
grids/ne30pg2.nc  -> grids/cmip6_180x360_scrip.20180901.nc
     ;;	 