### PR TITLE
Hmb nni fix

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,12 +1,8 @@
-2020-06-14  Charlie Zender  <zender@uci.edu>
+2020-06-15 Henry Butowsky  <henryb@hush.com>
 
-	* Use --uio flag within regridder, and everywhere except nco_msh_wrt(), nco_msh_poly_lst_wrt()
-
-	* Add --uio flag to ncclimo, mainly for splitter, and to ncremap (still not used internally by regridder, though)
-
-2020-06-11  Charlie Zender  <zender@uci.edu>
-
-	* Document --uio, --share
+	* inception of wgt_sct a lightweight version of poly_sct used when overlap mesh is not requested
+	  nco_ply_lst_mk_vrl_sph() - can now return wgt_sct**
+	  nco_msh_mk() - can now deal with overlap list of wgt_sct **
 
 2020-06-10  Charlie Zender  <zender@uci.edu>
 

--- a/src/nco/nco.h
+++ b/src/nco/nco.h
@@ -1090,7 +1090,14 @@ extern "C" {
     nco_edg_crt, /* [enm] Edges/arcs are Cartesian/planar lines and neglect curvature */
   } nco_edg_typ_enm;
 
-  typedef enum nco_xtr_typ_enm 
+  typedef enum nco_wgt_typ_enm{
+    nco_wgt_nil=0,
+    nco_wgt_con,   /* conservative algorithm */
+    nco_wgt_nni,   /* nearest neighbor interpolation */
+    nco_wgt_bln    /* bilinear interpolation */
+  } nco_wgt_typ_enm;
+
+typedef enum nco_xtr_typ_enm
     { /* [enm] Extrapolation type enum */
      nco_xtr_fll_lnr=0, // Perform linear extrapolation using two nearest valid neighbors
      nco_xtr_fll_ngh, // Set extrapolated value to value of nearest valid neighbor
@@ -1240,6 +1247,7 @@ extern "C" {
     nco_ply_tri_mth_typ_enm ply_tri_mth; /* [enm] Polygon-to-triangle decomposition method */ 
     nco_edg_typ_enm edg_typ; /* [enm] Arc-type for triangle edges */
     nco_xtr_typ_enm xtr_mth; /* [enm] Extrapolation method */
+    nco_wgt_typ_enm wgt_typ; /* [enm] Weight generation type */
     // Other internal data and metadata 
     char **xtn_var; /* [sng] Extensive variables */
     char *cmd_ln; /* [sng] Command-line */

--- a/src/nco/nco.h
+++ b/src/nco/nco.h
@@ -1680,7 +1680,17 @@ extern "C" {
     double *dp_xyz;  /* maybe useful for 3D stuff */
 
   } poly_sct;
-  
+
+  typedef struct{
+    int src_id;
+    int dst_id;
+    double area;
+    double wgt;
+
+} wgt_sct;
+
+
+
 #ifdef __cplusplus
 } /* end extern "C" */
 #endif /* !__cplusplus */

--- a/src/nco/nco_kd.h
+++ b/src/nco/nco_kd.h
@@ -240,6 +240,7 @@ typedef struct KDPpriority
 
 typedef struct {
     poly_sct **pl_lst;
+    wgt_sct **wgt_lst;
     size_t pl_cnt;
     size_t blk_nbr;
     KDPriority *kd_list;

--- a/src/nco/nco_ply_lst.h
+++ b/src/nco/nco_ply_lst.h
@@ -89,13 +89,14 @@ int pl_cnt_in,
 KDTree *rtree,
 int *pl_cnt_vrl_ret);
 
-poly_sct **
+void **
 nco_poly_lst_mk_vrl_sph(  /* create overlap mesh  for sph polygons */
 poly_sct **pl_lst_in,
 int pl_cnt_in,
 nco_grd_lon_typ_enm grd_lon_typ,
 KDTree **tree,
 int nbr_tr,
+int lst_out_typ,
 int *pl_cnt_vrl_ret);
 
 void
@@ -121,6 +122,12 @@ poly_sct **pl_lst_out,
 int pl_cnt_out,
 poly_sct **pl_lst_vrl,
 int pl_cnt_vrl);
+
+void
+nco_mem_lst_cat(
+omp_mem_sct *mem_lst,
+int sz_lst);
+
 
 #ifdef __cplusplus
 } /* end extern "C" */


### PR DESCRIPTION
@czender 
new member wgt_sct - used instead of poly_sct  in nco_msh_mk() when the overlap mesh is NOT requested.

new enum  nco_wgt_typ_enm  for  rgr->wgt_typ -
The prefix wgt is pretty overused in NCO so if you wish me to modify the struct name wgt_sct let me know.

Sorry I overwrote your code tidy up in nco_msh_mk(() and nco_ply_lst_mk_vrl_sph() - but it was a pretty complex merge - so I will reinstate  this after the PR

