### PR TITLE
Mantissa rounding for precision-reserving conversion

### DIFF
--- a/src/nco/nco.h
+++ b/src/nco/nco.h
@@ -727,6 +727,7 @@ extern "C" {
     nco_baa_set, /* 2 Bit Set (option since 20160117) */
     nco_baa_dgr, /* 3 Digit Rounding (GCD19 option since 20190121) */
     nco_baa_bg2, /* 4 Bit Groom version 2 dynamic masks (option since 20190203) */
+    nco_baa_rnd, /* 5 Bit rounding */
   }; /* end nco_baa_cnv */
 
   enum nco_bnr_cnv{ /* [enm] Binary byte-ordering convention to employ (native or byte-swapped) */

--- a/src/nco/nco_ppc.c
+++ b/src/nco/nco_ppc.c
@@ -774,6 +774,31 @@ nco_ppc_bitmask /* [fnc] Mask-out insignificant bits of significand */
 	 ncks -O -C -D 1 --baa=4 -v ppc_bgr --ppc default=3 ~/nco/data/in.nc ~/foo.nc
 	 ncks -O -C -D 1 --baa=4 -v one_dmn_rec_var_flt --ppc default=3 ~/nco/data/in.nc ~/foo.nc */
       if(nco_dbg_lvl_get() >= nco_dbg_std) (void)fprintf(stdout,"%s: DEBUG nco_ppc_bitmask() reports val = %g\n",nco_prg_nm_get(),op1.fp[idx]);
+    }else if(nco_baa_cnv_get() == nco_baa_rnd){
+      /* Round mantissa, LSBs to zero*/
+      /*idea: properly rounded mantissa using floating-point arithmetics (except for shaving LSB)*/
+      float val_tmp; /* Quantized value RK */
+      unsigned int *u32_ptr_tmp; /*pointer to it for shaving*/
+      u32_ptr_tmp = (unsigned int*) &val_tmp;
+      if(!has_mss_val){
+	for(idx=0L;idx<sz;idx++) {
+	  val_tmp = op1.fp[idx]; /* save it*/
+          u32_ptr_tmp[0] &= msk_f32_u32_zro; /*shave it*/
+          op1.fp[idx] *= 2; /*double unshaved*/
+          op1.fp[idx] -= val_tmp; /*subtract shaved*/
+          u32_ptr[idx]&=msk_f32_u32_zro; /*shave again*/
+        }
+      }else{
+	const float mss_val_flt=*mss_val.fp;
+	for(idx=0L;idx<sz;idx++)
+	  if(op1.fp[idx] != mss_val_flt){ 
+            val_tmp = op1.fp[idx]; /* save it*/
+            u32_ptr_tmp[0] &= msk_f32_u32_zro; /*shave it*/
+            op1.fp[idx] *= 2; /*double unshaved*/
+            op1.fp[idx] -= val_tmp; /*subtract shaved*/
+            u32_ptr[idx]&=msk_f32_u32_zro; /*shave again*/
+          };
+      } /* end else */
     }else abort();
     break;
   case NC_DOUBLE:


### PR DESCRIPTION
Hi Charlie,
I have stumbled on some nasty features of bit grooming and  implemented the proper rounding for mantissa, which, probably, should be the default method of PPC. At least I could not imagine any application where rounding would not be preferable over all others. 
It can be triggered with --baa 5 for floats for now. Should be straightforward
to implement for double, if someone really wants to apply ppc to double instead of converting them to float first.

I have noticed from the code that you have been  working on a paper on the subject. I would be happy to contribute there with the method and few illustrations of bit-grooming and other packing artifacts on synthetic and geophysical fields. Please let me know if you are interested. 
Thank you!
