### PR TITLE
Implemented baa=6 for half-shave (rectifying Bit Groomed data)

### DIFF
--- a/src/nco/nco.h
+++ b/src/nco/nco.h
@@ -728,6 +728,7 @@ extern "C" {
     nco_baa_dgr, /* 3 Digit Rounding (GCD19 option since 20190121) */
     nco_baa_bg2, /* 4 Bit Groom version 2 dynamic masks (option since 20190203) */
     nco_baa_rnd, /* 5 Bit rounding */
+    nco_baa_sh2, /* 6 Bit Half-shave  */
   }; /* end nco_baa_cnv */
 
   enum nco_bnr_cnv{ /* [enm] Binary byte-ordering convention to employ (native or byte-swapped) */

--- a/src/nco/nco_ppc.c
+++ b/src/nco/nco_ppc.c
@@ -802,6 +802,23 @@ nco_ppc_bitmask /* [fnc] Mask-out insignificant bits of significand */
 	  } /* !mss_val_flt */
 	} /* !idx */
       } /* !has_mss_val */
+    }else if(nco_baa_cnv_get() == nco_baa_sh2){
+      /* Bit-Half-Shave: shave LSBs and set MSB of them*/
+      unsigned int msk_f32_u32_hshv;
+      msk_f32_u32_hshv =  msk_f32_u32_one & (msk_f32_u32_zro >> 1); /*set one bit: the MSB of LSBs*/
+      if(!has_mss_val){
+	for(idx=0L;idx<sz;idx++) {
+                u32_ptr[idx] &= msk_f32_u32_zro; /*shave*/
+                u32_ptr[idx] |= msk_f32_u32_hshv; /*set msb of lsbs*/
+        }
+      }else{
+	const float mss_val_flt=*mss_val.fp;
+	for(idx=0L;idx<sz;idx++)
+	  if(op1.fp[idx] != mss_val_flt) {
+                u32_ptr[idx] &= msk_f32_u32_zro; /*shave*/
+                u32_ptr[idx] |= msk_f32_u32_hshv; /*set msb of lsbs*/
+          }
+      } /* end else */
     }else abort();
     break; /* !NC_FLOAT */
   case NC_DOUBLE:
@@ -890,6 +907,23 @@ nco_ppc_bitmask /* [fnc] Mask-out insignificant bits of significand */
 	  } /* !mss_val_dbl */
 	} /* !idx */
       } /* !has_mss_val */
+    }else if(nco_baa_cnv_get() == nco_baa_sh2){
+      /* Bit-Half-Shave: shave LSBs and set MSB of them*/
+      unsigned long int msk_f64_u64_hshv;
+      msk_f64_u64_hshv =  msk_f64_u64_one & (msk_f64_u64_zro >> 1); /*set one bit: the MSB of LSBs*/
+      if(!has_mss_val){
+	for(idx=0L;idx<sz;idx++) {
+                u64_ptr[idx] &= msk_f64_u64_zro; /*shave*/
+                u64_ptr[idx] |= msk_f64_u64_hshv; /*set msb of lsbs*/
+        }
+      }else{
+	const double mss_val_dbl=*mss_val.dp;
+	for(idx=0L;idx<sz;idx++)
+	  if(op1.dp[idx] != mss_val_dbl) {
+                u64_ptr[idx] &= msk_f64_u64_zro; /*shave*/
+                u64_ptr[idx] |= msk_f64_u64_hshv; /*set msb of lsbs*/
+          }
+      } /* end else */
     }else abort();
     break; /* !NC_DOUBLE */
   case NC_INT: /* Do nothing for non-floating point types ...*/


### PR DESCRIPTION
Here is an example ozone field in stratosphere from Silam, processed with ppc =2 with different baa, including the new one. Note the spatial patterns due to the crossing of a binary order contour.
![reldiff-groom](https://user-images.githubusercontent.com/11734464/87535758-aac00780-c6a0-11ea-8915-4509df08d2fe.png)
![reldiff-halfshave](https://user-images.githubusercontent.com/11734464/87535766-abf13480-c6a0-11ea-8ede-99824855686f.png)
![reldiff-round](https://user-images.githubusercontent.com/11734464/87535768-ac89cb00-c6a0-11ea-8a73-64f4859df33d.png)
![reldiff-shave](https://user-images.githubusercontent.com/11734464/87535769-ac89cb00-c6a0-11ea-88e2-caba950b0376.png)

