### PR TITLE
Hmb dwe fix

### DIFF
--- a/src/nco/nco_map.c
+++ b/src/nco/nco_map.c
@@ -1051,11 +1051,16 @@ nco_msh_mk /* [fnc] Compute overlap mesh and weights */
       fprintf(stderr, "%s: INFO: num input polygons=%lu, num output polygons=%lu num overlap weights(nni)=%d\n", nco_prg_nm_get(), grd_sz_in, grd_sz_out, pl_cnt_vrl);
 
 
+    /* dont really like this - for weight of input cells  maybe greater than 1 - some maybe 0.0  */
+    for(idx=0;idx<pl_cnt_vrl;idx++)
+      pl_lst_in[ wgt_lst_vrl[idx]->src_id]->wgt+=wgt_lst_vrl[idx]->wgt;
 
     for (idx = 0; idx < nbr_tr; idx++)
       kd_destroy(tree[idx], NULL);
 
     tree = (KDTree **) nco_free(tree);
+
+
 
 
 

--- a/src/nco/nco_ply_lst.c
+++ b/src/nco/nco_ply_lst.c
@@ -1534,7 +1534,7 @@ int *wgt_cnt_bln_ret) {
 
     }
 
-    if(False && dp_x_wrp != KD_DBL_MAX)
+    if(dp_x_wrp != KD_DBL_MAX)
     {
       for (kdx = 0; kdx < nbr_tr; kdx++)
         kd_nearest(tree[kdx], dp_x_wrp, pl_lst_out[idx]->dp_y_ctr, pl_typ, nbr_dwe, mem_lst[thr_idx].kd_list + nbr_lst_lcl+nbr_dwe * kdx);


### PR DESCRIPTION
@czender
Have modified nco_msh_mk() so that  weights for input grid cells are calculated  for _dwe  option. 
i.e frac_a is calculated
For some  maps maybe frac_a >1.0 and frac_a==0.0




 

