### PR TITLE
Document that ncap2 requires no [input_file]

### DIFF
--- a/man/ncap2.1
+++ b/man/ncap2.1
@@ -30,8 +30,8 @@ ncap2 [\-3] [\-4] [\-5] [\-6] [\-7] [\-A] [\-\-bfr
 .IR script ] [\-t
 .IR thr_nbr ] [\-\-uio] [\-v 
 .IR var [,...]]
-.I input-file [
-.I output-file ]
+.I [ input-file ] 
+.I output-file 
 .SH DESCRIPTION
 .PP
 .B ncap2

--- a/src/nco/nco_ctl.c
+++ b/src/nco/nco_ctl.c
@@ -932,7 +932,7 @@ nco_usg_prn(void)
 
   switch(prg_lcl){
   case ncap:
-    opt_sng=(char *)strdup("[-3] [-4] [-5] [-6] [-7] [-A] [--bfr byt] [-C] [-c] [--cnk_byt byt] [--cnk_csh byt] [--cnk_dmn nm,lmn] [--cnk_map map] [--cnk_min byt] [--cnk_plc plc] [--cnk_scl lmn] [-D dbg_lvl] [-F] [-f] [--fl_fmt fmt] [--glb ...] [-h] [--hdf] [--hdr_pad nbr] [--hpss] [-L lvl] [-l path] [--no_tmp_fl] [-O] [-o out.nc] [-p path] [-R] [-r] [--ram_all] [-s algebra] [-S fl.nco] [-t thr_nbr] [--uio] [-v] in.nc [out.nc]\n");
+    opt_sng=(char *)strdup("[-3] [-4] [-5] [-6] [-7] [-A] [--bfr byt] [-C] [-c] [--cnk_byt byt] [--cnk_csh byt] [--cnk_dmn nm,lmn] [--cnk_map map] [--cnk_min byt] [--cnk_plc plc] [--cnk_scl lmn] [-D dbg_lvl] [-F] [-f] [--fl_fmt fmt] [--glb ...] [-h] [--hdf] [--hdr_pad nbr] [--hpss] [-L lvl] [-l path] [--no_tmp_fl] [-O] [-o out.nc] [-p path] [-R] [-r] [--ram_all] [-s algebra] [-S fl.nco] [-t thr_nbr] [--uio] [-v] [in.nc] [out.nc]\n");
     break;
   case ncatted:
     opt_sng=(char *)strdup("[-a ...] [--bfr byt] [-D dbg_lvl] [--glb ...] [-h] [--hdr_pad nbr] [--hpss] [-l path] [-O] [-o out.nc] [-p path] [-R] [-r] [-t] [--uio] in.nc [[out.nc]]\n");


### PR DESCRIPTION
ncap2 does not require an input file but does seem to require an output file

If the output file doesn't depend on inputs, the input_file is not required per https://sourceforge.net/p/nco/discussion/9829/thread/131d984ab3/#6e25/d716 and http://nco.sourceforge.net/nco.html#ncap2-netCDF-Arithmetic-Processor 

For instance: 

    ncap2 -s 'print(1)' junk.nc

... creates junk.nc with no dimensions or variables but with a global history attribute.  If run repeatedly, then the history accumulates.