### PR TITLE
Add all NetCDF/HDF5 dependencies to CMAKE_REQUIRED_LIBRARIES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,7 +149,10 @@ endif()
 #check for header file netcdf_mem.h existence
 #/////////////////////////////////////////////////////////////////////////////////////
 
-set(CMAKE_REQUIRED_LIBRARIES ${NETCDF_LIBRARY})
+set(NETCDF_REQUIRED_LIBRARIES ${NETCDF_LIBRARY} ${HDF5_HL_LIBRARY} ${HDF5_LIBRARY} ${ZLIB_LIBRARY} ${SZIP_LIBRARY})
+# Replace backslashes with forward slashes because it can cause problems with Windows' paths
+string(REPLACE "\\" "/" NETCDF_REQUIRED_LIBRARIES ${NETCDF_REQUIRED_LIBRARIES})
+set(CMAKE_REQUIRED_LIBRARIES ${NETCDF_REQUIRED_LIBRARIES})
 
 check_library_exists(${NETCDF_LIBRARY} nc_rename_grp "" has_nc_rename_grp)
 if (has_nc_rename_grp)
@@ -236,7 +239,10 @@ endif()
 #which is not a requirement for the library to build successfully
 #//////////////////////////
 
-set(CMAKE_REQUIRED_LIBRARIES ${HDF5_LIBRARY})
+set(HDF5_REQUIRED_LIBRARIES ${HDF5_HL_LIBRARY} ${HDF5_LIBRARY} ${ZLIB_LIBRARY} ${SZIP_LIBRARY})
+# Replace backslashes with forward slashes because it can cause	problems with Windows' paths
+string(REPLACE "\\" "/" HDF5_REQUIRED_LIBRARIES ${HDF5_REQUIRED_LIBRARIES})
+set(CMAKE_REQUIRED_LIBRARIES ${HDF5_REQUIRED_LIBRARIES})
 
 message("-- Detecting if HDF5 library ${HDF5_LIBRARY} needs the ZLIB library...")
 check_library_exists(${HDF5_LIBRARY} H5Z_DEFLATE "" NEED_ZLIB)


### PR DESCRIPTION
All dependencies need to be linked in so that CMake can properly check for the desired features.

When using static libraries the checks to detect NetCDF and HDF5 features will always fail and cause issues when building.

Fixes #227 


These changes worked for me, but I'd like to see someone else try and build this with your usual workflow. Slightly more advanced logic may be needed to only link in the libraries that are present. But if those library variables are empty then they'll have no effect, so I think it might be fine.
