### PR TITLE
Removed unsupported -d option for ncap2 from man

### DIFF
--- a/man/ncap2.1
+++ b/man/ncap2.1
@@ -9,10 +9,6 @@ ncap2 \- netCDF Arithmetic Processor, Next Generation
 ncap2 [\-3] [\-4] [\-5] [\-6] [\-7] [\-A] [\-\-bfr
 .IR sz_byt ] [\-C] [\-c] [\-D 
 .IR dbg_lvl ]
-[\-d 
-.IR dim ,[
-.IR min ][,[
-.IR max ]]]
 [-F] [--fl_fmt=fmt] [\-f]
 [\-\-glb
 .IR att_name=


### PR DESCRIPTION
Fix an error in the man page