### PR TITLE
test parsing of BYTE/SHORT/INT/INT64 at mins

### DIFF
--- a/bm/NCO_rgr.pm
+++ b/bm/NCO_rgr.pm
@@ -552,6 +552,18 @@ if($USER eq 'zender'){
    $tst_cmd[3]="SS_OK";
    NCO_bm::tst_run(\@tst_cmd);
    $#tst_cmd=0; # Reset array
+
+
+# ncap2 #20
+   $dsc_sng="Run test limits script";
+   $tst_cmd[0]="ncap2 -4 -h -O $fl_fmt $nco_D_flg -v -S '../data/limits_tst.nco' $in_pth_arg in.nc %tmp_fl_00%";
+   $tst_cmd[1]="ncks -C -H --trd -v nbr_err_ttl -s '%d' %tmp_fl_00%";
+   $tst_cmd[2]="0";
+   $tst_cmd[3]="SS_OK";
+   NCO_bm::tst_run(\@tst_cmd);
+   $#tst_cmd=0; # Reset array
+
+
     
     if($dodap eq "FALSE"){
 ####################

--- a/data/limits.nco
+++ b/data/limits.nco
@@ -29,9 +29,9 @@ nbr_err_ttl=0;
 
 
 
- short_max=65535s;
+ short_max=32767s;
 
- if( -short_max -1 != -65536s ) {
+ if( -short_max -1 != -32768s ) {
   print("ERROR: short min\n");
   nbr_err++;
   }

--- a/data/limits.nco
+++ b/data/limits.nco
@@ -1,0 +1,72 @@
+// $Header$ -*-C++-*-
+
+// Purpose: Test parsing of naked numbers min/max
+
+/* Usage: 
+   ncap2 -4 -O -v -S ~/nco/data/limits.nco ~/nco/data/in4.nc ~/foo.nc
+   ncks ~/foo.nc | /bin/more */
+
+// Check methods first
+
+// Count number of errors
+nbr_err=0;
+nbr_err_ttl=0;
+{
+ 
+ byte_max=127b;
+ byte_min= -128b; 
+
+
+ if( -byte_max -1 != -128b ) {
+  print("ERROR: byte 1  min\n");
+  nbr_err++;
+  }
+
+ if( -byte_max -1 != byte_min ) {
+  print("ERROR: byte 2  min\n");
+  nbr_err++;
+  }
+
+
+
+ short_max=65535s;
+
+ if( -short_max -1 != -65536s ) {
+  print("ERROR: short min\n");
+  nbr_err++;
+  }
+
+
+
+ int_max=2147483647l;
+
+ if( -int_max -1 != -2147483648l ) {
+  print("ERROR: int min\n");
+  nbr_err++;
+  }
+
+
+ llong_max=9223372036854775807ll;
+
+ if( -llong_max -1 != -9223372036854775808ll ) {
+  print("ERROR: llong min\n");
+  nbr_err++;
+  }
+
+
+  print("RESULTS block 1  Num errors="); print(nbr_err,"%d");
+  nbr_err_ttl+=nbr_err;
+  nbr_err=0;
+
+
+}
+
+
+// Results summany
+print("RESULTS SUMMARY: total errors=");print(nbr_err_ttl,"%d");
+
+
+
+
+
+


### PR DESCRIPTION
test script  data/limits.nco   run in NCO_rgr.pm.
Checks parsing of naked numbers  values BYTE_MIN SHORT_MIN INT_MIN INT64_MIN

failing for INT64_MIN

 