### PR TITLE
Update paths to e3sm-unified following new layout

### DIFF
--- a/configure.eg
+++ b/configure.eg
@@ -354,9 +354,9 @@ scp nco.configure.foo nco.config.log.foo nco.libtool.foo nco.make.foo dust.ess.u
 export LINUX_CC='gcc -std=c99 -pedantic -D_DEFAULT_SOURCE'
 export LINUX_CXX='g++ -std=c++11'
 export LINUX_FC='gfortran'
-export NETCDF_ROOT=/ccs/proj/cli115/software/e3sm-unified/base/envs/e3sm_unified_latest
-export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/ccs/proj/cli115/software/e3sm-unified/base/envs/e3sm_unified_latest/lib
-export PATH=${PATH}:/ccs/proj/cli115/software/e3sm-unified/base/envs/e3sm_unified_latest/bin
+export NETCDF_ROOT=/ccs/proj/cli115/software/e3sm-unified/e3smu_latest_for_nco/andes 
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/ccs/proj/cli115/software/e3sm-unified/e3smu_latest_for_nco/andes/lib
+export PATH=${PATH}:/ccs/proj/cli115/software/e3sm-unified/e3smu_latest_for_nco/andes/bin
 cd ~/nco;git reset --hard origin/master
 cd ~/nco;CC=${LINUX_CC} CXX=${LINUX_CXX} NETCDF_ROOT=${HOME}/anaconda ./configure --prefix=${HOME} --bindir=${MY_BIN_DIR} --datadir=${HOME}/nco/data --libdir=${MY_LIB_DIR} --mandir=${HOME}/nco/man > nco.configure.foo 2>&1
 # !Andes
@@ -420,9 +420,9 @@ cd ~/nco;/bin/rm -f *.foo;make distclean
 export LINUX_CC='gcc -std=c99 -pedantic -D_DEFAULT_SOURCE -fopenmp'
 export LINUX_CXX='g++ -std=c++11 -fopenmp'
 export LINUX_FC='gfortran'
-export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/lcrc/soft/climate/e3sm-unified/base/envs/e3sm_unified_latest/lib
-export NETCDF_ROOT=/lcrc/soft/climate/e3sm-unified/base/envs/e3sm_unified_latest
-export PATH=${PATH}:/lcrc/soft/climate/e3sm-unified/base/envs/e3sm_unified_latest/bin
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/lcrc/soft/climate/e3sm-unified/e3smu_latest_for_nco/chrysalis/lib
+export NETCDF_ROOT=/lcrc/soft/climate/e3sm-unified/e3smu_latest_for_nco/chrysalis
+export PATH=${PATH}:/lcrc/soft/climate/e3sm-unified/e3smu_latest_for_nco/chrysalis/bin
 cd ~/nco;git reset --hard origin/master
 cd ~/nco;CC=${LINUX_CC} CXX=${LINUX_CXX} NETCDF_ROOT=${HOME}/anaconda ./configure --prefix=${HOME} --bindir=${MY_BIN_DIR} --datadir=${HOME}/nco/data --libdir=${MY_LIB_DIR} --mandir=${HOME}/nco/man > nco.configure.foo 2>&1
 /bin/cp -f config.log nco.config.log.foo
@@ -507,12 +507,12 @@ export LINUX_FC='gfortran'
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${HOME}/anaconda/lib
 export NETCDF_ROOT=${HOME}/anaconda
 export PATH=${PATH}:${HOME}/anaconda/bin
-#export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/ccs/proj/cli115/software/e3sm-unified/base/envs/e3sm_unified_latest/lib
-#export NETCDF_ROOT=/ccs/proj/cli115/software/e3sm-unified/base/envs/e3sm_unified_latest
-#export PATH=${PATH}:/ccs/proj/cli115/software/e3sm-unified/base/envs/e3sm_unified_latest/bin
+#export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/ccs/proj/cli115/software/e3sm-unified/e3smu_latest_for_nco/frontier/lib
+#export NETCDF_ROOT=/ccs/proj/cli115/software/e3sm-unified/e3smu_latest_for_nco/frontier
+#export PATH=${PATH}:/ccs/proj/cli115/software/e3sm-unified/e3smu_latest_for_nco/frontier/bin
 cd ~/nco;git reset --hard origin/master
 cd ~/nco/bld;make ANTLR_ROOT=${HOME}/anaconda ANTLR_LIB=${HOME}/anaconda NETCDF_ROOT=${HOME}/anaconda OPTS=D OMP=Y allinone;cd -
-cd ~/nco/bld;make ANTLR_ROOT=${HOME} ANTLR_LIB=${MY_LIB_DIR} NETCDF_ROOT='/ccs/proj/cli115/software/e3sm-unified/base/envs/e3sm_unified_latest' OPTS=D OMP=Y allinone;cd -
+cd ~/nco/bld;make ANTLR_ROOT=${HOME} ANTLR_LIB=${MY_LIB_DIR} NETCDF_ROOT='/ccs/proj/cli115/software/e3sm-unified/e3smu_latest_for_nco/frontier' OPTS=D OMP=Y allinone;cd -
 # !Frontier
 
 # gcc/g++ Zender uses this to develop/install/update netCDF4-enabled NCO in personal directories on Perlmutter with GNU:
@@ -528,12 +528,12 @@ cd ~/nco;/bin/rm -f *.foo;make distclean
 export LINUX_CC='gcc -std=c99 -pedantic -D_DEFAULT_SOURCE'
 export LINUX_CXX='g++ -std=c++11'
 export LINUX_FC='gfortran'
-export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/global/common/software/e3sm/anaconda_envs/base/envs/e3sm_unified_latest/lib
-export NETCDF_ROOT=/global/common/software/e3sm/anaconda_envs/base/envs/e3sm_unified_latest
-export PATH=${PATH}:/global/common/software/e3sm/anaconda_envs/base/envs/e3sm_unified_latest/bin
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/global/common/software/e3sm/anaconda_envs/e3smu_latest_for_nco/pm-cpu/lib
+export NETCDF_ROOT=/global/common/software/e3sm/anaconda_envs/e3smu_latest_for_nco/pm-cpu
+export PATH=${PATH}:/global/common/software/e3sm/anaconda_envs/e3smu_latest_for_nco/pm-cpu/bin
 cd ~/nco;git reset --hard origin/master
 cd ~/nco;CC=${LINUX_CC} CXX=${LINUX_CXX} NETCDF_ROOT=${HOME}/anaconda ./configure --prefix=${HOME} --bindir=${MY_BIN_DIR} --datadir=${HOME}/nco/data --libdir=${MY_LIB_DIR} --mandir=${HOME}/nco/man > nco.configure.foo 2>&1
-cd ~/nco;CC=${LINUX_CC} CPPFLAGS="-I${DATA}/anaconda/include -I/global/common/software/e3sm/anaconda_envs/base/envs/e3sm_unified_latest/include" CXX=${LINUX_CXX} LDFLAGS="-L${DATA}/anaconda/lib -L/global/common/software/e3sm/anaconda_envs/base/envs/e3sm_unified_latest/lib" NETCDF_ROOT=${DATA}/anaconda UDUNITS2_ROOT=${HOME} ./configure --prefix=${DATA} --bindir=${MY_BIN_DIR} --datadir=${HOME}/nco/data --libdir=${MY_LIB_DIR} --mandir=${HOME}/nco/man > nco.configure.foo 2>&1
+cd ~/nco;CC=${LINUX_CC} CPPFLAGS="-I${DATA}/anaconda/include -I/global/common/software/e3sm/anaconda_envs/e3smu_latest_for_nco/pm-cpu/include" CXX=${LINUX_CXX} LDFLAGS="-L${DATA}/anaconda/lib -L/global/common/software/e3sm/anaconda_envs/e3smu_latest_for_nco/pm-cpu/lib" NETCDF_ROOT=${DATA}/anaconda UDUNITS2_ROOT=${HOME} ./configure --prefix=${DATA} --bindir=${MY_BIN_DIR} --datadir=${HOME}/nco/data --libdir=${MY_LIB_DIR} --mandir=${HOME}/nco/man > nco.configure.foo 2>&1
 /bin/cp -f config.log nco.config.log.foo
 /bin/cp -f libtool nco.libtool.foo
 make clean;make > nco.make.foo 2>&1

--- a/data/ncclimo
+++ b/data/ncclimo
@@ -144,15 +144,27 @@ if [ "${hrd_pth}" = 'Yes' ] && [ "${NCO_PATH_OVERRIDE}" = 'Yes' ]; then
 	andes* )
 	    # 20190827: Must guarantee finding mpirun
 	    source ${MODULESHOME}/init/sh # 20150607: PMC Ensures find module commands will be found
-	    E3SMU_ROOT='/ccs/proj/cli115/software/e3sm-unified/base/envs/e3sm_unified_latest'
-            export PATH='/ccs/home/zender/bin_andes'\:${PATH}
+        if [ -d '/ccs/proj/cli115/software/e3sm-unified/e3smu_latest_for_nco' ]; then
+            E3SMU_ROOT='/ccs/proj/cli115/software/e3sm-unified/e3smu_latest_for_nco/andes'
+        else
+            E3SMU_ROOT='/ccs/proj/cli115/software/e3sm-unified/base/envs/e3sm_unified_latest'
+        fi
+        export PATH='/ccs/home/zender/bin_andes'\:${PATH}
 	    export LD_LIBRARY_PATH='/ccs/home/zender/lib_andes'\:${E3SMU_ROOT}/lib\:${LD_LIBRARY_PATH} ; ;;
 	blues* | blogin* | b[0123456789][0123456789][0123456789] )
-	    E3SMU_ROOT='/lcrc/soft/climate/e3sm-unified/base/envs/e3sm_unified_latest'
+        if [ -d '/lcrc/soft/climate/e3sm-unified/e3smu_latest_for_nco' ]; then
+            E3SMU_ROOT='/lcrc/soft/climate/e3sm-unified/e3smu_latest_for_nco/anvil'
+        else
+            E3SMU_ROOT='/lcrc/soft/climate/e3sm-unified/base/envs/e3sm_unified_latest'
+        fi
 	    export PATH='/home/zender/bin_blues'\:${PATH}
 	    export LD_LIBRARY_PATH='/home/zender/lib_blues'\:${E3SMU_ROOT}/lib\:${LD_LIBRARY_PATH} ; ;;
 	chrysalis* | chrlogin* | chr-[0123456789][0123456789][0123456789][0123456789] )
-	    E3SMU_ROOT='/lcrc/soft/climate/e3sm-unified/base/envs/e3sm_unified_latest'
+        if [ -d '/lcrc/soft/climate/e3sm-unified/e3smu_latest_for_nco' ]; then
+            E3SMU_ROOT='/lcrc/soft/climate/e3sm-unified/e3smu_latest_for_nco/chrysalis'
+        else
+            E3SMU_ROOT='/lcrc/soft/climate/e3sm-unified/base/envs/e3sm_unified_latest'
+        fi
 	    export PATH='/home/ac.zender/bin_chrysalis'\:${PATH}
 	    export LD_LIBRARY_PATH='/home/ac.zender/lib_chrysalis:/home/ac.zender/anaconda/lib'\:${E3SMU_ROOT}/lib\:${LD_LIBRARY_PATH} ; ;;
 	compy* | n[0123456789][0123456789][0123456789][0123456789] )
@@ -161,7 +173,11 @@ if [ "${hrd_pth}" = 'Yes' ] && [ "${NCO_PATH_OVERRIDE}" = 'Yes' ]; then
 	    # 20210519: This script takes significant time (5-10 seconds) to load
 	    # 20230914: Deprecate special MOAB paths, rely on E3SMU
 	    # source /compyfs/software/mbtempest.envs.sh
-	    E3SMU_ROOT='/share/apps/E3SM/conda_envs/base/envs/e3sm_unified_latest'
+        if [ -d '/share/apps/E3SM/conda_envs/e3smu_latest_for_nco' ]; then
+            E3SMU_ROOT='/share/apps/E3SM/conda_envs/e3smu_latest_for_nco/compy'
+        else
+            E3SMU_ROOT='/share/apps/E3SM/conda_envs/base/envs/e3sm_unified_latest'
+        fi
 	    export PATH='/qfs/people/zender/bin:/qfs/people/zender/anaconda/bin'\:${PATH}
 	    export LD_LIBRARY_PATH='/qfs/people/zender/lib:/qfs/people/zender/anaconda/lib'\:${LD_LIBRARY_PATH} ; ;;
 	derecho* )
@@ -180,13 +196,21 @@ if [ "${hrd_pth}" = 'Yes' ] && [ "${NCO_PATH_OVERRIDE}" = 'Yes' ]; then
 	    export LD_LIBRARY_PATH='/home/zender/lib:/home/zender/anaconda/lib'\:${LD_LIBRARY_PATH} ; ;;
 	frontier* )
 	    if [ ${spt_nm} = 'ncremap' ]; then
-		E3SMU_ROOT='/ccs/proj/cli115/software/e3sm-unified/base/envs/e3sm_unified_latest'
+            if [ -d '/ccs/proj/cli115/software/e3sm-unified/e3smu_latest_for_nco' ]; then
+                E3SMU_ROOT='/ccs/proj/cli115/software/e3sm-unified/e3smu_latest_for_nco/frontier'
+            else
+                E3SMU_ROOT='/ccs/proj/cli115/software/e3sm-unified/base/envs/e3sm_unified_latest'
+            fi
 	    fi # !ncremap
             export PATH='/ccs/home/zender/bin_frontier:/ccs/home/zender/anaconda/bin'\:${PATH}
 	    export LD_LIBRARY_PATH='/ccs/home/zender/lib_frontier:/ccs/home/zender/anaconda/lib'\:${LD_LIBRARY_PATH} ; ;;
 	login[0123456789][0123456789] ) # 20230831 Frontier and Perlmutter login nodes share this name :(
 	    if [ "${LMOD_SYSTEM_NAME}" = 'frontier' ]; then
-		E3SMU_ROOT='/ccs/proj/cli115/software/e3sm-unified/base/envs/e3sm_unified_latest'
+            if [ -d '/ccs/proj/cli115/software/e3sm-unified/e3smu_latest_for_nco' ]; then
+                E3SMU_ROOT='/ccs/proj/cli115/software/e3sm-unified/e3smu_latest_for_nco/frontier'
+            else
+                E3SMU_ROOT='/ccs/proj/cli115/software/e3sm-unified/base/envs/e3sm_unified_latest'
+            fi
 		export PATH='/ccs/home/zender/bin_frontier:/ccs/home/zender/anaconda/bin'\:${PATH}
 		export LD_LIBRARY_PATH='/ccs/home/zender/lib_frontier:/ccs/home/zender/anaconda/lib'\:${LD_LIBRARY_PATH}
 	    elif [ "${LMOD_SYSTEM_NAME}" = 'perlmutter' ]; then
@@ -196,7 +220,11 @@ if [ "${hrd_pth}" = 'Yes' ] && [ "${NCO_PATH_OVERRIDE}" = 'Yes' ]; then
 		module load cray-netcdf/4.9.0.9
 		MOAB_ROOT=/project/projectdirs/e3sm/software/moab
 		TEMPESTREMAP_ROOT=/project/projectdirs/e3sm/software/tempestremap
-		E3SMU_ROOT='/global/common/software/e3sm/anaconda_envs/base/envs/e3sm_unified_latest'
+        if [ -d '/global/common/software/e3sm/anaconda_envs/e3smu_latest_for_nco' ]; then
+            E3SMU_ROOT='/global/common/software/e3sm/anaconda_envs/e3smu_latest_for_nco/pm-cpu'
+        else
+            E3SMU_ROOT='/global/common/software/e3sm/anaconda_envs/base/envs/e3sm_unified_latest'
+        fi
 		if [ -n "${NCARG_ROOT}" ]; then
 		    export PATH="${PATH}:${NCARG_ROOT}/bin"
 		    export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${NCARG_ROOT}/lib"
@@ -212,7 +240,11 @@ if [ "${hrd_pth}" = 'Yes' ] && [ "${NCO_PATH_OVERRIDE}" = 'Yes' ]; then
 	    module load cray-netcdf/4.9.0.9
 	    MOAB_ROOT=/project/projectdirs/e3sm/software/moab
 	    TEMPESTREMAP_ROOT=/project/projectdirs/e3sm/software/tempestremap
-	    E3SMU_ROOT='/global/common/software/e3sm/anaconda_envs/base/envs/e3sm_unified_latest'
+        if [ -d '/global/common/software/e3sm/anaconda_envs/e3smu_latest_for_nco' ]; then
+            E3SMU_ROOT='/global/common/software/e3sm/anaconda_envs/e3smu_latest_for_nco/pm-cpu'
+        else
+            E3SMU_ROOT='/global/common/software/e3sm/anaconda_envs/base/envs/e3sm_unified_latest'
+        fi
 	    if [ -n "${NCARG_ROOT}" ]; then
 		export PATH="${PATH}:${NCARG_ROOT}/bin"
 		export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${NCARG_ROOT}/lib"

--- a/data/ncremap
+++ b/data/ncremap
@@ -161,15 +161,27 @@ if [ "${hrd_pth}" = 'Yes' ] && [ "${NCO_PATH_OVERRIDE}" = 'Yes' ]; then
 	andes* )
 	    # 20190827: Must guarantee finding mpirun
 	    source ${MODULESHOME}/init/sh # 20150607: PMC Ensures find module commands will be found
-	    E3SMU_ROOT='/ccs/proj/cli115/software/e3sm-unified/base/envs/e3sm_unified_latest'
-            export PATH='/ccs/home/zender/bin_andes'\:${PATH}
+        if [ -d '/ccs/proj/cli115/software/e3sm-unified/e3smu_latest_for_nco' ]; then
+            E3SMU_ROOT='/ccs/proj/cli115/software/e3sm-unified/e3smu_latest_for_nco/andes'
+        else
+            E3SMU_ROOT='/ccs/proj/cli115/software/e3sm-unified/base/envs/e3sm_unified_latest'
+        fi
+        export PATH='/ccs/home/zender/bin_andes'\:${PATH}
 	    export LD_LIBRARY_PATH='/ccs/home/zender/lib_andes:/ccs/home/zender/anaconda/lib'\:${E3SMU_ROOT}/lib\:${LD_LIBRARY_PATH} ; ;;
 	blues* | blogin* | b[0123456789][0123456789][0123456789] )
-	    E3SMU_ROOT='/lcrc/soft/climate/e3sm-unified/base/envs/e3sm_unified_latest'
+        if [ -d '/lcrc/soft/climate/e3sm-unified/e3smu_latest_for_nco' ]; then
+            E3SMU_ROOT='/lcrc/soft/climate/e3sm-unified/e3smu_latest_for_nco/anvil'
+        else
+            E3SMU_ROOT='/lcrc/soft/climate/e3sm-unified/base/envs/e3sm_unified_latest'
+        fi
 	    export PATH='/home/zender/bin_blues'\:${PATH}
 	    export LD_LIBRARY_PATH='/home/zender/lib_blues'\:${E3SMU_ROOT}/lib\:${LD_LIBRARY_PATH} ; ;;
 	chrysalis* | chrlogin* | chr-[0123456789][0123456789][0123456789][0123456789] )
-	    E3SMU_ROOT='/lcrc/soft/climate/e3sm-unified/base/envs/e3sm_unified_latest'
+        if [ -d '/lcrc/soft/climate/e3sm-unified/e3smu_latest_for_nco' ]; then
+            E3SMU_ROOT='/lcrc/soft/climate/e3sm-unified/e3smu_latest_for_nco/chrysalis'
+        else
+            E3SMU_ROOT='/lcrc/soft/climate/e3sm-unified/base/envs/e3sm_unified_latest'
+        fi
 	    export PATH='/home/ac.zender/bin_chrysalis'\:${PATH}
 	    export LD_LIBRARY_PATH='/home/ac.zender/lib_chrysalis:/home/ac.zender/anaconda/lib'\:${E3SMU_ROOT}/lib\:${LD_LIBRARY_PATH} ; ;;
 	compy* | n[0123456789][0123456789][0123456789][0123456789] )
@@ -178,7 +190,11 @@ if [ "${hrd_pth}" = 'Yes' ] && [ "${NCO_PATH_OVERRIDE}" = 'Yes' ]; then
 	    # 20210519: This script takes significant time (5-10 seconds) to load
 	    # 20230914: Deprecate special MOAB paths, rely on E3SMU
 	    # source /compyfs/software/mbtempest.envs.sh
-	    E3SMU_ROOT='/share/apps/E3SM/conda_envs/base/envs/e3sm_unified_latest'
+        if [ -d '/share/apps/E3SM/conda_envs/e3smu_latest_for_nco' ]; then
+            E3SMU_ROOT='/share/apps/E3SM/conda_envs/e3smu_latest_for_nco/compy'
+        else
+            E3SMU_ROOT='/share/apps/E3SM/conda_envs/base/envs/e3sm_unified_latest'
+        fi
 	    export PATH='/qfs/people/zender/bin:/qfs/people/zender/anaconda/bin'\:${PATH}
 	    export LD_LIBRARY_PATH='/qfs/people/zender/lib:/qfs/people/zender/anaconda/lib'\:${LD_LIBRARY_PATH} ; ;;
 	derecho* )
@@ -197,13 +213,21 @@ if [ "${hrd_pth}" = 'Yes' ] && [ "${NCO_PATH_OVERRIDE}" = 'Yes' ]; then
 	    export LD_LIBRARY_PATH='/home/zender/lib:/home/zender/anaconda/lib'\:${LD_LIBRARY_PATH} ; ;;
 	frontier* )
 	    if [ ${spt_nm} = 'ncremap' ]; then
-		E3SMU_ROOT='/ccs/proj/cli115/software/e3sm-unified/base/envs/e3sm_unified_latest'
+            if [ -d '/ccs/proj/cli115/software/e3sm-unified/e3smu_latest_for_nco' ]; then
+                E3SMU_ROOT='/ccs/proj/cli115/software/e3sm-unified/e3smu_latest_for_nco/frontier'
+            else
+                E3SMU_ROOT='/ccs/proj/cli115/software/e3sm-unified/base/envs/e3sm_unified_latest'
+            fi
 	    fi # !ncremap
             export PATH='/ccs/home/zender/bin_frontier:/ccs/home/zender/anaconda/bin'\:${PATH}
 	    export LD_LIBRARY_PATH='/ccs/home/zender/lib_frontier:/ccs/home/zender/anaconda/lib'\:${LD_LIBRARY_PATH} ; ;;
 	login[0123456789][0123456789] ) # 20230831 Frontier and Perlmutter login nodes share this name :(
 	    if [ "${LMOD_SYSTEM_NAME}" = 'frontier' ]; then
-		E3SMU_ROOT='/ccs/proj/cli115/software/e3sm-unified/base/envs/e3sm_unified_latest'
+            if [ -d '/ccs/proj/cli115/software/e3sm-unified/e3smu_latest_for_nco' ]; then
+                E3SMU_ROOT='/ccs/proj/cli115/software/e3sm-unified/e3smu_latest_for_nco/frontier'
+            else
+                E3SMU_ROOT='/ccs/proj/cli115/software/e3sm-unified/base/envs/e3sm_unified_latest'
+            fi
 		export PATH='/ccs/home/zender/bin_frontier:/ccs/home/zender/anaconda/bin'\:${PATH}
 		export LD_LIBRARY_PATH='/ccs/home/zender/lib_frontier:/ccs/home/zender/anaconda/lib'\:${LD_LIBRARY_PATH}
 	    elif [ "${LMOD_SYSTEM_NAME}" = 'perlmutter' ]; then
@@ -213,7 +237,11 @@ if [ "${hrd_pth}" = 'Yes' ] && [ "${NCO_PATH_OVERRIDE}" = 'Yes' ]; then
 		module load cray-netcdf/4.9.0.9
 		MOAB_ROOT=/project/projectdirs/e3sm/software/moab
 		TEMPESTREMAP_ROOT=/project/projectdirs/e3sm/software/tempestremap
-		E3SMU_ROOT='/global/common/software/e3sm/anaconda_envs/base/envs/e3sm_unified_latest'
+        if [ -d '/global/common/software/e3sm/anaconda_envs/e3smu_latest_for_nco' ]; then
+            E3SMU_ROOT='/global/common/software/e3sm/anaconda_envs/e3smu_latest_for_nco/pm-cpu'
+        else
+            E3SMU_ROOT='/global/common/software/e3sm/anaconda_envs/base/envs/e3sm_unified_latest'
+        fi
 		if [ -n "${NCARG_ROOT}" ]; then
 		    export PATH="${PATH}:${NCARG_ROOT}/bin"
 		    export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${NCARG_ROOT}/lib"
@@ -229,7 +257,11 @@ if [ "${hrd_pth}" = 'Yes' ] && [ "${NCO_PATH_OVERRIDE}" = 'Yes' ]; then
 	    module load cray-netcdf/4.9.0.9
 	    MOAB_ROOT=/project/projectdirs/e3sm/software/moab
 	    TEMPESTREMAP_ROOT=/project/projectdirs/e3sm/software/tempestremap
-	    E3SMU_ROOT='/global/common/software/e3sm/anaconda_envs/base/envs/e3sm_unified_latest'
+        if [ -d '/global/common/software/e3sm/anaconda_envs/e3smu_latest_for_nco' ]; then
+            E3SMU_ROOT='/global/common/software/e3sm/anaconda_envs/e3smu_latest_for_nco/pm-cpu'
+        else
+            E3SMU_ROOT='/global/common/software/e3sm/anaconda_envs/base/envs/e3sm_unified_latest'
+        fi
 	    if [ -n "${NCARG_ROOT}" ]; then
 		export PATH="${PATH}:${NCARG_ROOT}/bin"
 		export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${NCARG_ROOT}/lib"


### PR DESCRIPTION
We've changed the layout of the conda environments as part of e3sm-unified `1.12.0`. For example, on chrysalis the conda environments are located in:
```
$ tree -L 1 /lcrc/soft/climate/e3sm-unified/base/envs/ 
├── e3sm_unified_1.9.0_login
├── e3sm_unified_1.9.1_anvil
├── e3sm_unified_1.9.1_chrysalis
├── e3sm_unified_1.9.1_login
├── e3sm_unified_1.9.2_anvil
├── e3sm_unified_1.9.2_chrysalis
├── e3sm_unified_1.9.2_login
├── e3sm_unified_1.9.3_anvil
├── e3sm_unified_1.9.3_chrysalis
├── e3sm_unified_1.9.3_login
└── e3sm_unified_latest -> /lcrc/soft/climate/e3sm-unified/base/envs/e3sm_unified_1.11.1_login
```
where all version were using the same `conda` installation.  Because of file permission updates needed, only one user (i.e. @xylar) was able to deploy e3sm-unified on a give machine irrespective of the version. 

Going forward, we are going to deploy with something like: 
```
$ tree -L 2 /lcrc/soft/climate/e3sm-unified/e3smu_*
└──/lcrc/soft/climate/e3sm-unified/e3smu_x_x_x/
    ├── chrysalis
        ├── conda
        └── spack
    └── anvil
        ├── conda
        └── spack
└──/lcrc/soft/climate/e3sm-unified/e3smu_y_y_y/
    └── chrysalis
        ├── conda
        └── spack
    └── anvil
        ├── conda
        └── spack
```
where each unified version will get it's own installation of conda, so that different users can deploy different unified versions on the same machine. 

For the symlinks to the `e3sm_unified_latest`, we've changed it so that they look like: 
```
$ tree -L 1 /lcrc/soft/climate/e3sm-unified/e3smu_latest_for_nco
└── chrysalis
└── anvil
└── README
```
where `chrysalis`/`anvil` will be the symlinks. We've changed the naming (and added a README) to make it clear to users that they shouldn't concerned with these. 

So, with these changes I've updated the `E3SMU` paths were I think its needed. I've done so with using a conditional check for the new layout, since we haven't done the release deployment yet so these symlinks haven't been created yet. 

@czender any thoughts or concerns you have would be appreciated! Also pining @xylar so he's in the loop. 