### PR TITLE
Add --rad (retain_all_dimensions) option to all data operators except ncap2

### DIFF
--- a/add-rad-option-ncecat.patch
+++ b/add-rad-option-ncecat.patch
@@ -1,0 +1,39 @@
+diff --git a/src/nco/ncecat.c b/src/nco/ncecat.c
+index 75b3f1d..xxxxx 100644
+--- a/src/nco/ncecat.c
++++ b/src/nco/ncecat.c
+@@ -155,6 +155,7 @@ main(int argc,char **argv)
+   nco_bool SHARE_CREATE=False; /* [flg] Create file in RAM */
+   nco_bool SHARE_OPEN=False; /* [flg] Open files with unbuffered I/O */
+   nco_bool EXTRACT_ASSOCIATED_COORDINATES=True;
++  nco_bool RETAIN_ALL_DIMS=False; /* [flg] Retain all dimensions */
+   nco_bool RM_RMT_FL_PST_PRC=True; /* Option R */
+   nco_bool WRT_TMP_FL=True; /* [flg] Write output to temporary file */
+   nco_bool flg_mmr_cln=True; /* [flg] Clean memory prior to exit */
+@@ -276,6 +277,10 @@ main(int argc,char **argv)
+     {\"version\",no_argument,0,0},
+     {\"vrs\",no_argument,0,0},
+     {\"unn\",no_argument,0,0},
++    {\"rad\",no_argument,0,0}, /* [flg] Retain all dimensions */
++    {\"retain_all_dimensions\",no_argument,0,0}, /* [flg] Retain all dimensions */
++    {\"orphan_dimensions\",no_argument,0,0}, /* [flg] Retain all dimensions */
++    {\"rph_dmn\",no_argument,0,0}, /* [flg] Retain all dimensions */
+     {\"bfr_sz_hnt\",required_argument,0,0},
+     {\"buffer_size_hint\",required_argument,0,0},
+     {\"cnk_byt\",required_argument,0,0},
+@@ -484,6 +489,7 @@ main(int argc,char **argv)
+         if(!strcmp(opt_crr,\"wrt_tmp_fl\") || !strcmp(opt_crr,\"write_tmp_fl\")) WRT_TMP_FL=True;
+         if(!strcmp(opt_crr,\"no_tmp_fl\")) WRT_TMP_FL=False;
+         if(!strcmp(opt_crr,\"unn\")) EXTRACT_ALL_COORDINATES=True;
++        if(!strcmp(opt_crr,\"rad\") || !strcmp(opt_crr,\"retain_all_dimensions\") || !strcmp(opt_crr,\"orphan_dimensions\") || !strcmp(opt_crr,\"rph_dmn\")) RETAIN_ALL_DIMS=True;
+       } /* opt != 0 */
+       /* Process short options */
+       switch(opt){
+@@ -633,7 +639,7 @@ main(int argc,char **argv)
+   /* Define dimensions, extracted groups, variables, and attributes in output file */
+   
+-  (void)nco_xtr_dfn(in_id,out_id,&cnk,dfl_lvl,gpe,md5,!FORCE_APPEND,True,False,nco_pck_plc,(char *)NULL,trv_tbl);
++  (void)nco_xtr_dfn(in_id,out_id,&cnk,dfl_lvl,gpe,md5,!FORCE_APPEND,True,RETAIN_ALL_DIMS,nco_pck_plc,(char *)NULL,trv_tbl);
+   
+   /* Catenate time-stamped command line to "history" global attribute */
+   if(HISTORY_APPEND) (void)nco_hst_att_cat(out_id,cmd_ln);

--- a/add-rad-option.patch
+++ b/add-rad-option.patch
@@ -1,0 +1,192 @@
+diff --git a/src/nco/ncra.c b/src/nco/ncra.c
+index 75b3f1d..xxxxx 100644
+--- a/src/nco/ncra.c
++++ b/src/nco/ncra.c
+@@ -276,6 +276,7 @@ main(int argc,char **argv)
+   nco_bool RAM_OPEN=False; /* [flg] Open (netCDF3-only) file(s) in RAM */
+   nco_bool SHARE_CREATE=False; /* [flg] Create (netCDF3-only) file(s) with unbuffered I/O */
+   nco_bool SHARE_OPEN=False; /* [flg] Open (netCDF3-only) file(s) with unbuffered I/O */
++  nco_bool RETAIN_ALL_DIMS=False; /* [flg] Retain all dimensions */
+   nco_bool RM_RMT_FL_PST_PRC=True; /* Option R */
+   nco_bool WRT_TMP_FL=True; /* [flg] Write output to temporary file */
+   nco_bool flg_cll_mth=True; /* [flg] Add/modify cell_methods attributes */
+@@ -387,6 +388,10 @@ main(int argc,char **argv)
+     {"no_tmp_fl",no_argument,0,0}, /* [flg] Do not write output to temporary file */
+     {"version",no_argument,0,0},
+     {"vrs",no_argument,0,0},
++    {"rad",no_argument,0,0}, /* [flg] Retain all dimensions */
++    {"retain_all_dimensions",no_argument,0,0}, /* [flg] Retain all dimensions */
++    {"orphan_dimensions",no_argument,0,0}, /* [flg] Retain all dimensions */
++    {"rph_dmn",no_argument,0,0}, /* [flg] Retain all dimensions */
+     /* Long options with argument, no short option counterpart */
+     {"bfr_sz_hnt",required_argument,0,0}, /* [B] Buffer size for netCDF-classic I/O (ignored/harmless for netCDF4) */
+     {"buffer_size_hint",required_argument,0,0}, /* [B] Buffer size for netCDF-classic I/O (ignored/harmless for netCDF4) */
+@@ -668,6 +673,7 @@ main(int argc,char **argv)
+       if(!strcmp(opt_crr,"wrt_tmp_fl") || !strcmp(opt_crr,"write_tmp_fl")) WRT_TMP_FL=True;
+       if(!strcmp(opt_crr,"no_tmp_fl")) WRT_TMP_FL=False;
++      if(!strcmp(opt_crr,"rad") || !strcmp(opt_crr,"retain_all_dimensions") || !strcmp(opt_crr,"orphan_dimensions") || !strcmp(opt_crr,"rph_dmn")) RETAIN_ALL_DIMS=True;
+     } /* opt != 0 */
+     /* Process short options */
+     switch(opt){
+@@ -976,7 +982,7 @@ main(int argc,char **argv)
+   
+   /* Define dimensions, extracted groups, variables, and attributes in output file */
+-  (void)nco_xtr_dfn(in_id,out_id,&cnk,dfl_lvl,gpe,md5,!FORCE_APPEND,!REC_APN,False,nco_pck_plc_nil,(char *)NULL,trv_tbl);
++  (void)nco_xtr_dfn(in_id,out_id,&cnk,dfl_lvl,gpe,md5,!FORCE_APPEND,!REC_APN,RETAIN_ALL_DIMS,nco_pck_plc_nil,(char *)NULL,trv_tbl);
+ 
+   /* Define ensemble fixed variables (True parameter) */
+   if(nco_prg_id_get() == ncge) (void)nco_nsm_dfn_wrt(in_id,out_id,&cnk,dfl_lvl,gpe,True,trv_tbl);
+
+diff --git a/src/nco/ncwa.c b/src/nco/ncwa.c
+index 75b3f1d..xxxxx 100644
+--- a/src/nco/ncwa.c
++++ b/src/nco/ncwa.c
+@@ -243,6 +243,7 @@ main(int argc,char **argv)
+   nco_bool SHARE_CREATE=False; /* [flg] Create (netCDF3-only) file(s) with unbuffered I/O */
+   nco_bool SHARE_OPEN=False; /* [flg] Open (netCDF3-only) file(s) with unbuffered I/O */
++  nco_bool RETAIN_ALL_DIMS=False; /* [flg] Retain all dimensions */
+   nco_bool RM_RMT_FL_PST_PRC=True; /* Option R */
+   nco_bool WGT_MSK_CRD_VAR=True; /* [flg] Weight and/or mask coordinate variables */
+   nco_bool WRT_TMP_FL=True; /* [flg] Write output to temporary file */
+@@ -387,6 +388,10 @@ main(int argc,char **argv)
+     {"normalize_weights",no_argument,0,0},
+     {"version",no_argument,0,0},
+     {"vrs",no_argument,0,0},
++    {"rad",no_argument,0,0}, /* [flg] Retain all dimensions */
++    {"retain_all_dimensions",no_argument,0,0}, /* [flg] Retain all dimensions */
++    {"orphan_dimensions",no_argument,0,0}, /* [flg] Retain all dimensions */
++    {"rph_dmn",no_argument,0,0}, /* [flg] Retain all dimensions */
+     /* Long options with argument, no short option counterpart */
+     {"bfr_sz_hnt",required_argument,0,0}, /* [B] Buffer size for netCDF-classic I/O */
+     {"buffer_size_hint",required_argument,0,0}, /* [B] Buffer size for netCDF-classic I/O */
+@@ -650,6 +655,7 @@ main(int argc,char **argv)
+       if(!strcmp(opt_crr,"wrt_tmp_fl") || !strcmp(opt_crr,"write_tmp_fl")) WRT_TMP_FL=True;
+       if(!strcmp(opt_crr,"no_tmp_fl")) WRT_TMP_FL=False;
++      if(!strcmp(opt_crr,"rad") || !strcmp(opt_crr,"retain_all_dimensions") || !strcmp(opt_crr,"orphan_dimensions") || !strcmp(opt_crr,"rph_dmn")) RETAIN_ALL_DIMS=True;
+     } /* opt != 0 */
+     /* Process short options */
+     switch(opt){
+@@ -852,7 +858,7 @@ main(int argc,char **argv)
+   /* Define dimensions, extracted groups, variables, and attributes in output file.  */
+-  (void)nco_xtr_dfn(in_id,out_id,&cnk,dfl_lvl,gpe,md5,!FORCE_APPEND,True,False,nco_pck_plc_nil,(char *)NULL,trv_tbl);
++  (void)nco_xtr_dfn(in_id,out_id,&cnk,dfl_lvl,gpe,md5,!FORCE_APPEND,True,RETAIN_ALL_DIMS,nco_pck_plc_nil,(char *)NULL,trv_tbl);
+ 
+   /* Catenate time-stamped command line to "history" global attribute */
+   if(HISTORY_APPEND) (void)nco_hst_att_cat(out_id,cmd_ln);
+
+diff --git a/src/nco/ncbo.c b/src/nco/ncbo.c
+index 75b3f1d..xxxxx 100644
+--- a/src/nco/ncbo.c
++++ b/src/nco/ncbo.c
+@@ -173,6 +173,7 @@ main(int argc,char **argv)
+   nco_bool SHARE_CREATE=False; /* [flg] Create file in RAM */
+   nco_bool SHARE_OPEN=False; /* [flg] Open files with unbuffered I/O */
+   nco_bool FILE_1_RETRIEVED_FROM_REMOTE_LOCATION;
++  nco_bool RETAIN_ALL_DIMS=False; /* [flg] Retain all dimensions */
+   nco_bool RM_RMT_FL_PST_PRC=True; /* Option R */
+   nco_bool WRT_TMP_FL=True; /* [flg] Write output to temporary file */
+   nco_bool flg_mmr_cln=True; /* [flg] Clean memory prior to exit */
+@@ -269,6 +270,10 @@ main(int argc,char **argv)
+     {"version",no_argument,0,0},
+     {"vrs",no_argument,0,0},
+     {"xcl_dmn_ass_var",no_argument,0,0},
++    {"rad",no_argument,0,0}, /* [flg] Retain all dimensions */
++    {"retain_all_dimensions",no_argument,0,0}, /* [flg] Retain all dimensions */
++    {"orphan_dimensions",no_argument,0,0}, /* [flg] Retain all dimensions */
++    {"rph_dmn",no_argument,0,0}, /* [flg] Retain all dimensions */
+     {"bfr_sz_hnt",required_argument,0,0},
+     {"buffer_size_hint",required_argument,0,0},
+     {"cnk_byt",required_argument,0,0},
+@@ -394,6 +399,7 @@ main(int argc,char **argv)
+       if(!strcmp(opt_crr,"xcl_dmn_ass_var")) GRP_VAR_UNN=True;
+       if(!strcmp(opt_crr,"wrt_tmp_fl") || !strcmp(opt_crr,"write_tmp_fl")) WRT_TMP_FL=True;
+       if(!strcmp(opt_crr,"no_tmp_fl")) WRT_TMP_FL=False;
++      if(!strcmp(opt_crr,"rad") || !strcmp(opt_crr,"retain_all_dimensions") || !strcmp(opt_crr,"orphan_dimensions") || !strcmp(opt_crr,"rph_dmn")) RETAIN_ALL_DIMS=True;
+     } /* opt != 0 */
+     /* Process short options */
+     switch(opt){
+@@ -624,7 +630,7 @@ main(int argc,char **argv)
+   /* Define extracted groups, variables, and attributes in output
+      Then (later) copy variable data for variables in grp_out */
+-  (void)nco_grp_brd(in_id_1,in_id_2,out_id,&cnk,dfl_lvl,gpe,(nco_bool)False,trv_tbl_1,trv_tbl_2,nco_op_typ);
++  (void)nco_grp_brd(in_id_1,in_id_2,out_id,&cnk,dfl_lvl,gpe,RETAIN_ALL_DIMS,trv_tbl_1,trv_tbl_2,nco_op_typ);
+ 
+   /* Catenate time-stamped command line to "history" global attribute */
+   if(HISTORY_APPEND) (void)nco_hst_att_cat(out_id,cmd_ln);
+
+diff --git a/src/nco/ncpdq.c b/src/nco/ncpdq.c
+index 75b3f1d..xxxxx 100644
+--- a/src/nco/ncpdq.c
++++ b/src/nco/ncpdq.c
+@@ -203,6 +203,7 @@ main(int argc,char **argv)
+   nco_bool SHARE_CREATE=False; /* [flg] Create file in RAM */
+   nco_bool SHARE_OPEN=False; /* [flg] Open files with unbuffered I/O */
++  nco_bool RETAIN_ALL_DIMS=False; /* [flg] Retain all dimensions */
+   nco_bool RM_RMT_FL_PST_PRC=True; /* Option R */
+   nco_bool WRT_TMP_FL=True; /* [flg] Write output to temporary file */
+   nco_bool flg_mmr_cln=True; /* [flg] Clean memory prior to exit */
+@@ -362,6 +363,10 @@ main(int argc,char **argv)
+     {"unpack",no_argument,0,'U'},
+     {"version",no_argument,0,0},
+     {"vrs",no_argument,0,0},
++    {"rad",no_argument,0,0}, /* [flg] Retain all dimensions */
++    {"retain_all_dimensions",no_argument,0,0}, /* [flg] Retain all dimensions */
++    {"orphan_dimensions",no_argument,0,0}, /* [flg] Retain all dimensions */
++    {"rph_dmn",no_argument,0,0}, /* [flg] Retain all dimensions */
+     {"bfr_sz_hnt",required_argument,0,0},
+     {"buffer_size_hint",required_argument,0,0},
+     {"cnk_byt",required_argument,0,0},
+@@ -590,6 +595,7 @@ main(int argc,char **argv)
+       if(!strcmp(opt_crr,"wrt_tmp_fl") || !strcmp(opt_crr,"write_tmp_fl")) WRT_TMP_FL=True;
+       if(!strcmp(opt_crr,"no_tmp_fl")) WRT_TMP_FL=False;
++      if(!strcmp(opt_crr,"rad") || !strcmp(opt_crr,"retain_all_dimensions") || !strcmp(opt_crr,"orphan_dimensions") || !strcmp(opt_crr,"rph_dmn")) RETAIN_ALL_DIMS=True;
+     } /* opt != 0 */
+     /* Process short options */
+     switch(opt){
+@@ -812,7 +818,7 @@ main(int argc,char **argv)
+   /* Define dimensions, extracted groups, variables, and attributes in output file. NB: record name is NULL */
+-  (void)nco_xtr_dfn(in_id,out_id,&cnk,dfl_lvl,gpe,md5,!FORCE_APPEND,True,False,nco_pck_plc,(char *)NULL,trv_tbl);
++  (void)nco_xtr_dfn(in_id,out_id,&cnk,dfl_lvl,gpe,md5,!FORCE_APPEND,True,RETAIN_ALL_DIMS,nco_pck_plc,(char *)NULL,trv_tbl);
+ 
+   /* Catenate time-stamped command line to "history" global attribute */
+   if(HISTORY_APPEND) (void)nco_hst_att_cat(out_id,cmd_ln);
+
+diff --git a/src/nco/ncflint.c b/src/nco/ncflint.c
+index 75b3f1d..xxxxx 100644
+--- a/src/nco/ncflint.c
++++ b/src/nco/ncflint.c
+@@ -178,6 +178,7 @@ main(int argc,char **argv)
+   nco_bool SHARE_CREATE=False; /* [flg] Create file in RAM */
+   nco_bool SHARE_OPEN=False; /* [flg] Open files with unbuffered I/O */
++  nco_bool RETAIN_ALL_DIMS=False; /* [flg] Retain all dimensions */
+   nco_bool RM_RMT_FL_PST_PRC=True; /* Option R */
+   nco_bool WRT_TMP_FL=True; /* [flg] Write output to temporary file */
+   nco_bool flg_mmr_cln=True; /* [flg] Clean memory prior to exit */
+@@ -314,6 +315,10 @@ main(int argc,char **argv)
+     {"version",no_argument,0,0},
+     {"vrs",no_argument,0,0},
+     {"wgt_var",no_argument,0,0},
++    {"rad",no_argument,0,0}, /* [flg] Retain all dimensions */
++    {"retain_all_dimensions",no_argument,0,0}, /* [flg] Retain all dimensions */
++    {"orphan_dimensions",no_argument,0,0}, /* [flg] Retain all dimensions */
++    {"rph_dmn",no_argument,0,0}, /* [flg] Retain all dimensions */
+     {"bfr_sz_hnt",required_argument,0,0},
+     {"buffer_size_hint",required_argument,0,0},
+     {"cnk_byt",required_argument,0,0},
+@@ -472,6 +477,7 @@ main(int argc,char **argv)
+       if(!strcmp(opt_crr,"wrt_tmp_fl") || !strcmp(opt_crr,"write_tmp_fl")) WRT_TMP_FL=True;
+       if(!strcmp(opt_crr,"no_tmp_fl")) WRT_TMP_FL=False;
++      if(!strcmp(opt_crr,"rad") || !strcmp(opt_crr,"retain_all_dimensions") || !strcmp(opt_crr,"orphan_dimensions") || !strcmp(opt_crr,"rph_dmn")) RETAIN_ALL_DIMS=True;
+     } /* opt != 0 */
+     /* Process short options */
+     switch(opt){
+@@ -748,7 +754,7 @@ main(int argc,char **argv)
+   /* Transfer variable type to table. NOTE: Using var/xtr_nbr containing all variables (processed, fixed) */
+   (void)nco_var_typ_trv(xtr_nbr,var,trv_tbl);         
+ 
+   /* Define dimensions, extracted groups, variables, and attributes in output file */
+-  (void)nco_xtr_dfn(in_id_1,out_id,&cnk,dfl_lvl,gpe,md5,!FORCE_APPEND,True,False,nco_pck_plc_nil,(char *)NULL,trv_tbl);
++  (void)nco_xtr_dfn(in_id_1,out_id,&cnk,dfl_lvl,gpe,md5,!FORCE_APPEND,True,RETAIN_ALL_DIMS,nco_pck_plc_nil,(char *)NULL,trv_tbl);
+ 
+   /* Catenate time-stamped command line to "history" global attribute */
+   if(HISTORY_APPEND) (void)nco_hst_att_cat(out_id,cmd_ln);


### PR DESCRIPTION
ncbo, ncpdq, nces, ncdiff, ncflint, ncfe, ncge operators

Implement the --rad option and its synonyms (--retain_all_dimensions, --orphan_dimensions, --rph_dmn) across all applicable operators. This option retains all dimensions in the output file, including those that are not referenced by extracted variables (orphaned dimensions).

The implementation adds:
- RETAIN_ALL_DIMS boolean flag declaration before RM_RMT_FL_PST_PRC
- Long option entries for rad, retain_all_dimensions, orphan_dimensions, and rph_dmn
- Option parsing logic to set RETAIN_ALL_DIMS when flag is provided
- Passing RETAIN_ALL_DIMS flag to nco_xtr_dfn() function call

Files modified:
- src/nco/ncra.c (also affects ncrcat, ncfe, ncge via shared code)
- src/nco/ncwa.c
- src/nco/ncbo.c
- src/nco/ncpdq.c
- src/nco/ncflint.c